### PR TITLE
Hand the agent the notes that are still asking

### DIFF
--- a/Support/test-notes.mjs
+++ b/Support/test-notes.mjs
@@ -1,0 +1,121 @@
+// Tests for the notes the agent is handed: which ones, and whether they still
+// point at anything.
+//
+//   node Support/test-notes.mjs
+//
+// Two bugs live here, and both were quiet. A quote holds the *rendered* text,
+// so every emphasised phrase compared unequal against the raw markdown and came
+// back marked orphan — which tells an agent to stop and ask instead of act. And
+// `notes` returned resolved notes along with the open ones, so a document on
+// its third round handed back twenty finished requests to bury the two live
+// ones.
+
+import { flatten, parseNotes } from '../plugin/scripts/imark.mjs'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+let failures = 0
+const check = (name, ok, detail = '') => {
+  if (ok) {
+    console.log(`OK   ${name}`)
+  } else {
+    failures += 1
+    console.log(`FAIL ${name}${detail ? ` — ${detail}` : ''}`)
+  }
+}
+
+// ------------------------------------------------------------------ flatten
+
+const same = (name, raw, rendered) =>
+  check(name, flatten(raw).includes(flatten(rendered)),
+    `${JSON.stringify(flatten(raw))} does not contain ${JSON.stringify(flatten(rendered))}`)
+
+console.log('▸ the raw line and the rendered quote flatten alike')
+same('bold', 'A **bold** word', 'A bold word')
+same('italic with stars', 'A *slanted* word', 'A slanted word')
+same('italic with underscores', 'A _slanted_ word', 'A slanted word')
+same('code span', 'Run `npm ci` first', 'Run npm ci first')
+same('struck through', 'It is ~~gone~~ now', 'It is gone now')
+same('a link is its words', 'See [the docs](https://x.dev) for more', 'See the docs for more')
+same('an image is its alt text', 'Here ![a cat](cat.png) sits', 'Here a cat sits')
+same('bold and code at once',
+  '1. **Nome da pasta.** `~/produtos/` ou preferes `~/projects/`?',
+  'Nome da pasta. ~/produtos/ ou preferes ~/projects/?')
+same('a paragraph the file wrapped', 'one line\nand the next', 'one line and the next')
+
+console.log('▸ and flattening leaves alone what is not formatting')
+check('a bullet is not emphasis', flatten('* item one\n* item two') === '* item one * item two',
+  JSON.stringify(flatten('* item one\n* item two')))
+check('stars inside code stay', flatten('`a*b*c` here') === 'a*b*c here',
+  JSON.stringify(flatten('`a*b*c` here')))
+check('underscores inside a word stay', flatten('the some_var_name thing') === 'the some_var_name thing',
+  JSON.stringify(flatten('the some_var_name thing')))
+check('numbers survive', flatten('In 2021 he made 3 things') === 'In 2021 he made 3 things',
+  JSON.stringify(flatten('In 2021 he made 3 things')))
+
+// ------------------------------------------------------------------ orphans
+
+const doc = [
+  '# Spec',
+  '',
+  '1. **Nome da pasta.** `~/produtos/` ou preferes `~/projects/`?',
+  '',
+  '<!-- imark quote="Nome da pasta. ~/produtos/ ou preferes ~/projects/?" by="m" at="2026-08-09T10:00Z"',
+  'Still open.',
+  '-->',
+  '',
+  'A plain paragraph.',
+  '',
+  '<!-- imark quote="A plain paragraph." by="m" at="2026-08-08T10:00Z" resolved="2026-08-09T09:00Z"',
+  'Already handled.',
+  '-->',
+  '',
+  '<!-- imark quote="a sentence nobody ever wrote" by="m" at="2026-08-08T11:00Z"',
+  'Genuinely lost.',
+  '-->',
+  '',
+].join('\n')
+
+console.log('▸ orphan means the words are gone, not that they were formatted')
+const notes = parseNotes(doc)
+check('the formatted quote is anchored', notes[0].orphan === false)
+check('the plain quote is anchored', notes[1].orphan === false)
+check('the missing quote is an orphan', notes[2].orphan === true)
+
+// -------------------------------------------------------------- the command
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'imark-notes-'))
+const file = path.join(dir, 'SPEC.md')
+fs.writeFileSync(file, doc)
+const script = new URL('../plugin/scripts/imark.mjs', import.meta.url).pathname
+const run = (...args) => execFileSync('node', [script, 'notes', file, ...args], { encoding: 'utf8' })
+
+console.log('▸ notes hands over the work, not the archive')
+const plain = run()
+check('the resolved note is left out', !plain.includes('Already handled'))
+check('the open one is there', plain.includes('Still open'))
+check('and so is the orphan, which is still open', plain.includes('Genuinely lost'))
+check('the header counts what it hid', plain.includes('2 active, 1 resolved — use --all to see them'),
+  plain.split('\n')[0])
+
+const all = run('--all')
+check('--all brings the resolved one back', all.includes('Already handled'))
+check('marked as resolved', all.includes('✓ Resolved 2026-08-09'))
+check('and the header goes quiet again', all.split('\n')[0].includes('(3)'), all.split('\n')[0])
+
+check('--json obeys the same rule', JSON.parse(run('--json')).length === 2)
+check('--all --json returns everything', JSON.parse(run('--all', '--json')).length === 3)
+
+fs.writeFileSync(file, '# T\n\nA paragraph.\n\n<!-- imark quote="A paragraph." by="m" at="2026-08-09T10:00Z"\nOne.\n-->\n')
+check('a file with nothing resolved keeps the plain count', run().split('\n')[0].includes('(1)'),
+  run().split('\n')[0])
+
+fs.writeFileSync(file, '# T\n\nNothing to see.\n')
+check('a file with no notes still says so', run().includes('_No notes._'))
+
+fs.rmSync(dir, { recursive: true, force: true })
+
+console.log(failures === 0 ? '\nall good' : `\n${failures} failing`)
+process.exit(failures === 0 ? 0 : 1)

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -20,8 +20,13 @@ Needs Imark in `/Applications` and Node 20.
 
 ```
 /imark:imark-review PLAN.md       # review a markdown document
-/imark:imark-notes PLAN.md        # notes you already left
+/imark:imark-notes PLAN.md        # the notes still waiting on something
 ```
+
+`imark-notes` hands over the open notes only. One you have already dealt with is
+marked `resolved=` and stays in the document as the record of what was asked, but
+it is history rather than work — the header says how many were held back, and
+`--all` produces them.
 
 Markdown only — plans, specs, RFCs, docs. Imark is a markdown reader, and
 reviewing code is a real job this is not the tool for; that is what GitHub or

--- a/plugin/commands/imark-notes.md
+++ b/plugin/commands/imark-notes.md
@@ -13,6 +13,11 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/imark.mjs" notes $ARGUMENTS
 This waits for nothing and opens nothing — it is for when the user has already
 commented and says "read my comments".
 
+What comes back is the notes still asking for something. One that was already
+acted on carries `resolved=` and stays in the document as the record of what was
+asked, but it is history, not work — the header says how many were held back,
+and `--all` produces them for when the history is what the user wants.
+
 Each note carries the words it is attached to, the section it fell under, and
 the block above it. That is usually enough to know what it is about without
 opening the file; open it anyway if a note needs the text around it.

--- a/plugin/scripts/imark.mjs
+++ b/plugin/scripts/imark.mjs
@@ -11,6 +11,7 @@ import crypto from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 const OPEN_LINE = /^\s*<!--\s*imark\b/
 const CLOSE_LINE = /^\s*-->\s*$/
@@ -45,6 +46,41 @@ function attributes(line) {
     out[match[1]] = unescapeAttribute(match[2])
   }
   return out
+}
+
+/**
+ * A line of markdown as the reader saw it, for comparing one against the other.
+ *
+ * `quote=` holds the *rendered* text — no `**`, no backticks, a link reduced to
+ * its words — while the anchor check looks for it in the raw source. The two
+ * have to be flattened the same way or every emphasised phrase reads as an
+ * orphan, and an orphan tells the agent to stop and ask instead of acting.
+ *
+ * This started as a lone `\s+` collapse, for a paragraph the file wraps over
+ * two lines and the quote carries as one. Inline formatting was the same bug a
+ * step further on. Both live in this one function now so they cannot drift
+ * apart again — every future rule belongs here too, on both sides at once.
+ */
+export function flatten(text) {
+  const code = []
+  return text
+    // Code spans first, contents parked out of reach: a `*` between backticks
+    // is a character, not emphasis, and stripping it would change the words.
+    .replace(/(`+)([^`]*?)\1/g, (_, __, inner) => `\u0000${code.push(inner) - 1}\u0000`)
+    // A link reads as its text. Images too — the alt text is what is spoken.
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/~~([\s\S]+?)~~/g, '$1')
+    // The delimiter has to hug its words: `**a**` is bold, but a `* ` opening a
+    // list item is a bullet, and pairing two of those across a list would join
+    // lines that never touched.
+    .replace(/\*\*(?!\s)([\s\S]+?)(?<!\s)\*\*/g, '$1')
+    .replace(/\*(?!\s)([\s\S]+?)(?<!\s)\*/g, '$1')
+    // Underscores only outside a word, or `some_var_name` loses its middle.
+    .replace(/(?<![\w])__(?!\s)([\s\S]+?)(?<!\s)__(?![\w])/g, '$1')
+    .replace(/(?<![\w])_(?!\s)([\s\S]+?)(?<!\s)_(?![\w])/g, '$1')
+    .replace(/\u0000(\d+)\u0000/g, (_, i) => code[Number(i)])
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 /**
@@ -96,11 +132,7 @@ export function parseNotes(source) {
   // Prose only — a quote that appears inside another note is not an anchor.
   const prose = lines.map((line, i) => (inside.has(i) ? '' : line))
 
-  // `quote=` holds the *rendered* text, so a paragraph the file wraps over two
-  // lines arrives with a space where the source has a newline. Comparing them
-  // literally marked freshly written notes as orphans, which tells an agent to
-  // distrust an anchor that is perfectly good.
-  const flat = prose.join('\n').replace(/\s+/g, ' ')
+  const flat = flatten(prose.join('\n'))
 
   for (const note of notes) {
     const at = note.line - 1
@@ -110,7 +142,7 @@ export function parseNotes(source) {
     }
     note.orphan = note.scope !== 'file'
       && note.quote !== ''
-      && !flat.includes(note.quote.replace(/\s+/g, ' ').trim())
+      && !flat.includes(flatten(note.quote))
   }
 
   return notes
@@ -398,12 +430,33 @@ function report(file, result, { ephemeral = false } = {}) {
 
 // ----------------------------------------------------------------- commands
 
+/**
+ * The notes in a document — by default only the ones still asking for
+ * something.
+ *
+ * A resolved note stays in the file forever, which is the point: it is the
+ * record of what was asked. But handing all of them back on every round buries
+ * the two that matter under twenty that are done, and invites an agent to
+ * solve the same thing twice. `--all` is there for when the history is what
+ * you actually want.
+ */
 async function cmdNotes(argv) {
   const file = argv.find((a) => !a.startsWith('-'))
-  if (!file) throw new Error('usage: imark.mjs notes <file.md> [--json]')
+  if (!file) throw new Error('usage: imark.mjs notes <file.md> [--all] [--json]')
+
   const notes = parseNotes(fs.readFileSync(file, 'utf8'))
-  if (argv.includes('--json')) say(JSON.stringify(notes, null, 2))
-  else say(`# Notes in ${path.basename(file)} (${notes.length})\n\n${formatNotes(notes)}`)
+  const all = argv.includes('--all')
+  const shown = all ? notes : notes.filter((note) => !note.resolved)
+  const hidden = notes.length - shown.length
+
+  if (argv.includes('--json')) return say(JSON.stringify(shown, null, 2))
+
+  // The count says what was left out as well as what is here, so an agent
+  // that needs the history knows it exists and how to ask for it.
+  const count = hidden > 0
+    ? `${shown.length} active, ${hidden} resolved — use --all to see them`
+    : `${shown.length}`
+  say(`# Notes in ${path.basename(file)} (${count})\n\n${formatNotes(shown)}`)
 }
 
 async function cmdReview(argv) {
@@ -539,19 +592,27 @@ async function cmdPlanHook() {
 
 // --------------------------------------------------------------------- main
 
-const [command, ...argv] = process.argv.slice(2)
+// Only when run as a command. This file exports its parser so tests can reach
+// it, and without the guard importing it ran the dispatch, printed the usage
+// line, and left the exports unusable for the thing they exist for.
+const invoked = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href
 
-try {
-  switch (command) {
-    case 'notes': await cmdNotes(argv); break
-    case 'review': await cmdReview(argv); break
-    case 'plan-hook': await cmdPlanHook(); break
-    case 'open': openInImark(argv[0]); break
-    default:
-      say('usage: imark.mjs <notes|review|open|plan-hook> …')
-      process.exit(command ? 1 : 0)
+if (invoked) {
+  const [command, ...argv] = process.argv.slice(2)
+
+  try {
+    switch (command) {
+      case 'notes': await cmdNotes(argv); break
+      case 'review': await cmdReview(argv); break
+      case 'plan-hook': await cmdPlanHook(); break
+      case 'open': openInImark(argv[0]); break
+      default:
+        say('usage: imark.mjs <notes|review|open|plan-hook> …')
+        process.exit(command ? 1 : 0)
+    }
+  } catch (error) {
+    process.stderr.write(`imark: ${error.message}\n`)
+    process.exit(1)
   }
-} catch (error) {
-  process.stderr.write(`imark: ${error.message}\n`)
-  process.exit(1)
 }

--- a/plugin/skills/imark-comments/SKILL.md
+++ b/plugin/skills/imark-comments/SKILL.md
@@ -26,9 +26,14 @@ Do not hand-roll a parser:
 node "${CLAUDE_PLUGIN_ROOT}/scripts/imark.mjs" notes <file.md>
 ```
 
-Add `--json` for structured output. Each note comes back with what it says, the
-quote it is attached to, who wrote it and when, the heading it falls under, and
-the block above it.
+By default this shows only the notes still asking for something. A note carrying
+`resolved=` has been dealt with — it stays in the file as the record of what was
+asked, but it is history, not work. The header says how many were left out. Add
+`--all` when the history is what you want.
+
+Add `--json` for structured output; it obeys the same rule. Each note comes back
+with what it says, the quote it is attached to, who wrote it and when, the
+heading it falls under, and the block above it.
 
 ## The format
 

--- a/release.sh
+++ b/release.sh
@@ -58,6 +58,7 @@ if [ "${1:-}" != "--force" ]; then
 		Support/test-comments.swift -o /tmp/imark-release-test >/dev/null 2>&1 \
 		&& /tmp/imark-release-test >/dev/null || die "the comment tests failed"
 	node Support/test-export.mjs >/dev/null 2>&1 || die "the export test failed"
+	node Support/test-notes.mjs >/dev/null 2>&1 || die "the note anchoring tests failed"
 	swiftc -parse-as-library Sources/Imark/Updates.swift Sources/Imark/Settings.swift \
 		Sources/Imark/NoteColour.swift Support/test-update.swift \
 		-o /tmp/imark-release-update >/dev/null 2>&1 \

--- a/renderer/src/comments.js
+++ b/renderer/src/comments.js
@@ -89,16 +89,23 @@ const unescapeHTML = (value) =>
 function blockAbove(root, line) {
   let best = null
   let bestEnd = -1
+  let around = null
   for (const child of root.children) {
     const raw = child.getAttribute('data-line')
     if (!raw) continue
-    const end = Number(raw.split(',')[1])
-    if (Number.isFinite(end) && end <= line && end > bestEnd) {
+    const [from, to] = raw.split(',').map(Number)
+    // A note written under a list item lands *inside* the list's own line
+    // range: markdown-it reads the comment as part of the list and stretches
+    // the block over it. Nothing then ends above the note except whatever came
+    // before the whole list, which is not what the note is about — the quote is
+    // not in there, so a perfectly good note read as an orphan.
+    if (Number.isFinite(from) && Number.isFinite(to) && from <= line && line <= to) around = child
+    if (Number.isFinite(to) && to <= line && to > bestEnd) {
       best = child
-      bestEnd = end
+      bestEnd = to
     }
   }
-  return best
+  return around ?? best
 }
 
 /// Every text node under a block, in order, so a quote can be looked for in the


### PR DESCRIPTION
Two bugs in `notes`, the command an agent runs to read your comments.

## 1. Formatted text was reported as an orphan

`quote=` stores the *rendered* text. The check looked for it in the raw markdown and only collapsed whitespace, so `**Folder name.**` never matched `Folder name.`

Every bold, italic, code or linked phrase came back as:

> ⚠️ Orphan — the quoted text is no longer in the document.

An orphan tells the agent to stop and ask instead of act, so this cost a round trip on every formatted line.

**Fix.** Both sides now go through one `flatten()` that strips inline formatting before comparing. A `* ` starting a list item, `some_var_name`, and a `*` inside backticks are left alone.

## 2. Resolved notes came back forever

`notes` returned every note, including ones already marked `resolved=`. A document on its third round handed back twenty finished requests along with the two that still mattered.

**Fix.**

| | |
|---|---|
| `notes file.md` | open notes only |
| `notes file.md --all` | everything, resolved ones marked |
| `--json` | same rule, same fields |

The header says what it held back:

```
# Notes in SPEC.md (2 active, 21 resolved — use --all to see them)
```

**Nothing is deleted.** The note stays in the file as the record of what was asked, faded in the app. Only what is shown changes.

## Before and after

One open note on a formatted line, one already resolved.

**Before**

```
# Notes in demo.md (2)

### Note 1 — on "Folder name. ~/products/ or would you prefer ~/projects/?"
⚠️ Orphan — the quoted text is no longer in the document.

Which one?

### Note 2 — on "generous but workable"
✓ Resolved 2026-08-08

Workable with which team? Needs a number.
```

**After**

```
# Notes in demo.md (1 active, 1 resolved — use --all to see them)

### Note 1 — on "Folder name. ~/products/ or would you prefer ~/projects/?"
> 1. **Folder name.** `~/products/` or would you prefer `~/projects/`?

Which one?
```

## The app had the same symptom, for a different reason

The app searches the rendered DOM, so formatting never affected it — but notes under a **list item** were orphaned there too. markdown-it counts the comment as part of the list, so nothing ends above the note and `blockAbove` fell back to whatever preceded the whole list.

A note that sits inside a block's line range now anchors to that block. Checked in a real WebView: two notes, one orphaned before, both anchored after.

## Notes

- The CLI dispatch is now behind a `main` guard. The file exports its parser, and importing it used to run the dispatch and print the usage line.
- New `Support/test-notes.mjs` (27 checks), wired into `release.sh`. It fails against the old code — one failure per bug — and passes against the new.
- All seven existing suites still pass. App rebuilt and checked against the file that exposed the bug: 4 orphans before, 0 after.