### PR TITLE
Undo puts the text back where it came from

### DIFF
--- a/Sources/Imark/Comments.swift
+++ b/Sources/Imark/Comments.swift
@@ -108,9 +108,18 @@ enum Comments {
         return out
     }
 
-    /// Puts a whole document back, for undo. No stamp check: the caller took
-    /// the snapshot and is the one asking for it back.
-    static func restore(_ text: String, to url: URL) throws {
+    /// Puts a whole document back, for undo.
+    ///
+    /// This is the only write in the app that replaces a file wholesale, which
+    /// makes it the only one that can cost somebody a document rather than a
+    /// comment. It used to skip the staleness check on the grounds that the
+    /// caller took the snapshot and is the one asking for it back — true, but
+    /// only until something else writes in between. An editor saving over the
+    /// file, or a `git checkout`, and the snapshot is a way to erase it.
+    static func restore(_ text: String, to url: URL, expecting stamp: Stamp?) throws {
+        if let stamp, let now = Stamp(of: url), now != stamp {
+            throw Failure.fileChanged
+        }
         try write(text, to: url)
     }
 

--- a/Sources/Imark/DocumentWindowController.swift
+++ b/Sources/Imark/DocumentWindowController.swift
@@ -20,7 +20,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate {
     /// A snapshot of the whole document before each change, which is what makes
     /// undo work the same for writing, editing and deleting a note. Documents
     /// are capped at 5 MB and the stack at ten, so this stays small.
-    private var undoStack: [(text: String, what: String)] = []
+    private var undoStack = UndoStack()
     /// Set while the composer is editing a note rather than writing a new one.
     private var editingNote: ClosedRange<Int>?
     private let commentsList = CommentsList()
@@ -29,7 +29,11 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate {
     /// Set while the composer is open for a note about the document rather than
     /// about anything in it. There is no selection behind such a note, so the
     /// save path has nothing else to tell them apart by.
-    private var composingFileNote = false
+    /// Reachable from Support/test-undo.swift, which drives a whole comment
+    /// through this controller rather than through the popover and the WebView.
+    /// A file note is the one kind that needs no selection, which makes it the
+    /// cheapest way to put a real change on the undo stack from a test.
+    var composingFileNote = false
     private(set) var reviewingComments = false
 
     private var watcher: FileWatcher?
@@ -150,7 +154,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate {
 
     // MARK: - Loading
 
-    private func show(_ target: URL, pushingHistory: Bool) {
+    func show(_ target: URL, pushingHistory: Bool) {
         if pushingHistory {
             back.append(url)
             forward.removeAll()
@@ -323,7 +327,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate {
     /// came from. This is the first thing Imark does that changes a document, so
     /// it goes through an atomic replace and refuses to write over a file that
     /// moved underneath it.
-    private func saveComment(_ body: String, colour: NoteColour) {
+    func saveComment(_ body: String, colour: NoteColour) {
         if let range = editingNote {
             return updateComment(body, colour: colour, at: range)
         }
@@ -348,6 +352,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate {
                 expecting: stamp
             )
             lastWrite = Date()
+            sealSnapshot()
             selectionPopover.dismiss()
             content.renderer.clearSelection()
             load()
@@ -357,7 +362,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate {
                 self?.content.renderer.revealNote(index)
             }
         } catch {
-            undoStack.removeLast()
+            undoStack.discardLast()
             selectionPopover.reportCommentFailure(
                 (error as? LocalizedError)?.errorDescription ?? "Couldn't save the comment"
             )
@@ -383,7 +388,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate {
                 try Comments.remove(lines: command.lines, from: url, expecting: stamp)
                 finishWrite()
             } catch {
-                undoStack.removeLast()
+                undoStack.discardLast()
                 report(error, doing: "delete that comment")
             }
         }
@@ -397,7 +402,7 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate {
             selectionPopover.dismiss()
             finishWrite()
         } catch {
-            undoStack.removeLast()
+            undoStack.discardLast()
             selectionPopover.reportCommentFailure(
                 (error as? LocalizedError)?.errorDescription ?? "Couldn't save the comment"
             )
@@ -405,12 +410,24 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate {
     }
 
     private func snapshot(_ what: String) {
-        undoStack.append((text: (try? String(contentsOf: url, encoding: .utf8)) ?? "", what: what))
-        if undoStack.count > 10 { undoStack.removeFirst() }
+        undoStack.push(
+            text: (try? String(contentsOf: url, encoding: .utf8)) ?? "",
+            what: what,
+            url: url,
+            stamp: nil
+        )
+    }
+
+    /// Called once a change has landed: the entry now knows what the file looks
+    /// like with the change in it, which is what makes an outside edit
+    /// afterwards detectable.
+    private func sealSnapshot() {
+        undoStack.stampLast(Comments.Stamp(of: url))
     }
 
     private func finishWrite() {
         lastWrite = Date()
+        sealSnapshot()
         load()
     }
 
@@ -424,10 +441,13 @@ final class DocumentWindowController: NSWindowController, NSWindowDelegate {
     }
 
     @objc func undoComment(_ sender: Any?) {
-        guard let last = undoStack.popLast() else { return NSSound.beep() }
+        guard !undoStack.isEmpty else { return NSSound.beep() }
         do {
-            try Comments.restore(last.text, to: url)
-            finishWrite()
+            // The stack knows which file each snapshot belongs to. This window
+            // may well be showing a different one by now.
+            try undoStack.undoLast()
+            lastWrite = Date()
+            load()
         } catch {
             report(error, doing: "undo that")
         }

--- a/Sources/Imark/UndoStack.swift
+++ b/Sources/Imark/UndoStack.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// The document as it was before each change, so a comment can be taken back.
+///
+/// A window outlives the document open in it — you follow a wiki-link, press
+/// Back, pick another file in the sidebar — so a snapshot has to carry the file
+/// it came from. Restoring "the current document" is how the text of one file
+/// ends up written over another.
+struct UndoStack {
+    struct Entry {
+        /// The whole file, before the change.
+        let text: String
+        /// What the change was, for the menu item: "Undo Delete Comment".
+        let what: String
+        /// The file this text belongs to. Not the one on screen when you undo.
+        let url: URL
+        /// What that file looked like when the snapshot was taken. If it does
+        /// not match at undo time, somebody else has written since.
+        let stamp: Comments.Stamp?
+    }
+
+    /// Ten is what a person can remember doing. Documents are capped at 5 MB,
+    /// so ten of them is still nothing.
+    static let limit = 10
+
+    private var entries: [Entry] = []
+
+    var isEmpty: Bool { entries.isEmpty }
+
+    /// The next thing an undo would take back, for naming the menu item.
+    var last: Entry? { entries.last }
+
+    mutating func push(text: String, what: String, url: URL, stamp: Comments.Stamp?) {
+        entries.append(Entry(text: text, what: what, url: url, stamp: stamp))
+        if entries.count > Self.limit { entries.removeFirst() }
+    }
+
+    /// Takes the newest entry off. Returns nil when there is nothing to undo.
+    mutating func pop() -> Entry? { entries.popLast() }
+
+    /// Records what the file looks like now that the change has landed, so an
+    /// edit made afterwards by somebody else can be told apart from our own.
+    mutating func stampLast(_ stamp: Comments.Stamp?) {
+        guard let entry = entries.popLast() else { return }
+        entries.append(Entry(text: entry.text, what: entry.what, url: entry.url, stamp: stamp))
+    }
+
+    /// Takes the newest change back, writing to the file it came from.
+    ///
+    /// The caller never names a file. That is the whole point: the window shows
+    /// whatever document you last opened, and asking it where to put the text
+    /// is how one file's contents ended up written over another's.
+    ///
+    /// Throws `Comments.Failure.fileChanged` if that file has moved on since —
+    /// an outside edit is somebody's work, and taking a comment back is not a
+    /// reason to erase it.
+    @discardableResult
+    mutating func undoLast() throws -> Entry? {
+        guard let entry = entries.popLast() else { return nil }
+        do {
+            try Comments.restore(entry.text, to: entry.url, expecting: entry.stamp)
+        } catch {
+            // Put it back: a refusal is not the same as having undone it, and
+            // the next ⌘Z should still offer the same change.
+            entries.append(entry)
+            throw error
+        }
+        // Writing just moved the file's timestamp, and the entry underneath was
+        // expecting the state we have this moment restored. Without this, a
+        // second ⌘Z reads its own predecessor as somebody else's edit and
+        // refuses — undo would only ever work once.
+        if entries.last?.url == entry.url {
+            stampLast(Comments.Stamp(of: entry.url))
+        }
+        return entry
+    }
+
+    /// Drops the newest entry without using it — for a change that was
+    /// snapshotted and then failed to write, which would otherwise leave an
+    /// undo offering to restore a file nobody changed.
+    mutating func discardLast() {
+        if !entries.isEmpty { entries.removeLast() }
+    }
+}

--- a/Support/test-comments.swift
+++ b/Support/test-comments.swift
@@ -203,9 +203,23 @@ enum CommentsTest {
                                 by: "m", on: date, into: url, expecting: nil)
         check("the note went in", try String(contentsOf: url, encoding: .utf8) != original)
 
-        try Comments.restore(original, to: url)
+        // Passing no stamp is "restore this, whatever the file looks like now".
+        // The window always passes one; the exhaustive cases live in
+        // Support/test-undo.swift, including the refusal.
+        try Comments.restore(original, to: url, expecting: nil)
         check("undo puts the file back exactly",
               try String(contentsOf: url, encoding: .utf8) == original)
+
+        // And with a stamp, restoring over somebody else's write is refused —
+        // the one guarantee this function used to be missing.
+        let stale = Comments.Stamp(of: url)
+        Thread.sleep(forTimeInterval: 1.1)
+        try "written by somebody else\n".write(to: url, atomically: true, encoding: .utf8)
+        var refused = false
+        do { try Comments.restore(original, to: url, expecting: stale) } catch { refused = true }
+        check("restoring over an outside write is refused", refused)
+        check("and that write is still there",
+              try String(contentsOf: url, encoding: .utf8) == "written by somebody else\n")
     }
 
     // MARK: - A range that no longer points at a note

--- a/Support/test-undo.swift
+++ b/Support/test-undo.swift
@@ -1,0 +1,252 @@
+// Tests for taking a comment back.
+//
+//   swiftc -parse-as-library $(find Sources/Imark -name '*.swift' ! -name main.swift) \
+//          $(find Sources/ImarkRender -name '*.swift') \
+//          Support/test-undo.swift -o /tmp/imark-test-undo && /tmp/imark-test-undo
+//
+// Undo is the only thing in Imark that writes a whole file at once. Everything
+// else edits a range of lines and checks the file first. That makes it the one
+// place where a mistake costs somebody a document rather than a comment, and it
+// had two: the snapshot went back to whichever file the window happened to be
+// showing, and it went back over an outside edit without a word.
+//
+// Most of it exercises the stack directly, which is where the rules live. The
+// last case goes the whole way through a real window — a real comment, a real
+// navigation, the real selector ⌘Z fires — because a correct model wired up
+// wrongly is still a lost document.
+
+import AppKit
+
+@main
+struct TestUndo {
+    static var failures = 0
+
+    static func check(_ name: String, _ ok: Bool, _ detail: String = "") {
+        if ok {
+            print("OK   \(name)")
+        } else {
+            failures += 1
+            print("FAIL \(name)\(detail.isEmpty ? "" : " — \(detail)")")
+        }
+    }
+
+    // A file per test, in its own directory, so nothing leaks between them.
+    static func fixture(_ text: String, named: String = "DOC.md") -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("imark-undo-\(UUID().uuidString)")
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(named)
+        try! text.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    static func read(_ url: URL) -> String {
+        (try? String(contentsOf: url, encoding: .utf8)) ?? "<unreadable>"
+    }
+
+    /// What the window does: snapshot, write, and seal the entry with what the
+    /// file looks like once the change has landed.
+    static func record(_ stack: inout UndoStack, _ what: String, on url: URL, change: () -> Void) {
+        stack.push(text: read(url), what: what, url: url, stamp: nil)
+        change()
+        stack.stampLast(Comments.Stamp(of: url))
+    }
+
+    /// What ⌘Z does — the real path the window calls.
+    static func undo(_ stack: inout UndoStack) throws -> Bool {
+        try stack.undoLast() != nil
+    }
+
+    static func main() {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.prohibited)
+
+        do {
+            try theOrdinaryCases()
+            try theStackItself()
+            try theFileItGoesBackTo()
+            try theFileChangingUnderneath()
+            try theWholeWayThroughTheWindow()
+        } catch {
+            failures += 1
+            print("FAIL threw: \(error)")
+        }
+
+        print(failures == 0 ? "\nall good" : "\n\(failures) failing")
+        exit(failures == 0 ? 0 : 1)
+    }
+
+    // MARK: - Writing, editing and deleting all come back the same way
+
+    static func theOrdinaryCases() throws {
+        print("▸ a change comes back exactly as it was")
+
+        for what in ["Comment", "Edit Comment", "Delete Comment"] {
+            let original = "# Doc\n\nA paragraph.\n"
+            let url = fixture(original)
+            var stack = UndoStack()
+
+            record(&stack, what, on: url) {
+                try? "# Doc\n\nA paragraph.\n\n<!-- imark quote=\"paragraph\" by=\"m\" at=\"2026-08-10T09:00Z\"\nA note.\n-->\n"
+                    .write(to: url, atomically: true, encoding: .utf8)
+            }
+            check("\(what.lowercased()) changed the file", read(url) != original)
+
+            _ = try undo(&stack)
+            check("undoing \(what.lowercased()) puts it back byte for byte", read(url) == original,
+                  String(read(url).prefix(60)))
+        }
+
+        print("▸ two changes undo newest first")
+        let url = fixture("one\n")
+        var stack = UndoStack()
+        record(&stack, "Comment", on: url) { try? "two\n".write(to: url, atomically: true, encoding: .utf8) }
+        record(&stack, "Comment", on: url) { try? "three\n".write(to: url, atomically: true, encoding: .utf8) }
+        _ = try undo(&stack)
+        check("the first undo goes back one step", read(url) == "two\n", read(url))
+        _ = try undo(&stack)
+        check("the second goes back to the start", read(url) == "one\n", read(url))
+    }
+
+    // MARK: - The stack's own rules
+
+    static func theStackItself() throws {
+        print("▸ the stack")
+
+        var empty = UndoStack()
+        check("an empty stack has nothing to undo", empty.isEmpty)
+        check("and undoing it does nothing at all", try undo(&empty) == false)
+
+        let url = fixture("x\n")
+        var stack = UndoStack()
+        for i in 0..<15 {
+            stack.push(text: "\(i)", what: "Comment", url: url, stamp: nil)
+        }
+        check("the stack stops at ten", stack.last?.what == "Comment")
+        var counted = 0
+        while stack.pop() != nil { counted += 1 }
+        check("keeping the ten newest", counted == UndoStack.limit, "kept \(counted)")
+
+        var failed = UndoStack()
+        failed.push(text: "before", what: "Comment", url: url, stamp: nil)
+        failed.discardLast()
+        check("a change that failed to write leaves nothing to undo", failed.isEmpty)
+
+        var named = UndoStack()
+        named.push(text: "before", what: "Delete Comment", url: url, stamp: nil)
+        check("the menu can name the action", named.last?.what == "Delete Comment")
+    }
+
+    // MARK: - Which file the text goes back to
+
+    static func theFileItGoesBackTo() throws {
+        print("▸ the snapshot goes back to its own file, not the one on screen")
+
+        // A window outlives the document in it: comment on A, follow a link to
+        // B, press ⌘Z. Before this was fixed, A's whole text landed on B.
+        let a = fixture("# A\n\nThe first document.\n", named: "A.md")
+        let b = fixture("# B\n\nThe second document, which must survive.\n", named: "B.md")
+        let bBefore = read(b)
+
+        var stack = UndoStack()
+        record(&stack, "Comment", on: a) {
+            try? "# A\n\nThe first document.\n\n<!-- imark quote=\"first\" by=\"m\" at=\"2026-08-10T09:00Z\"\nA note.\n-->\n"
+                .write(to: a, atomically: true, encoding: .utf8)
+        }
+
+        // The window is now showing B. The stack still holds A.
+        _ = try undo(&stack)
+
+        check("the other document is untouched", read(b) == bBefore, String(read(b).prefix(60)))
+        check("and the comment came out of the one it was made in",
+              read(a) == "# A\n\nThe first document.\n", String(read(a).prefix(60)))
+    }
+
+    // MARK: - Somebody else writing in between
+
+    static func theFileChangingUnderneath() throws {
+        print("▸ an outside edit is not something to write over")
+
+        let url = fixture("# Doc\n\nA paragraph.\n")
+        var stack = UndoStack()
+        record(&stack, "Comment", on: url) {
+            try? "# Doc\n\nA paragraph.\n\n<!-- imark quote=\"paragraph\" by=\"m\" at=\"2026-08-10T09:00Z\"\nA note.\n-->\n"
+                .write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        // The file changes on disk: another editor saves over it, Imark
+        // reloads, and the undo stack is still holding a snapshot from before
+        // any of that. Restoring it would erase the outside work.
+        Thread.sleep(forTimeInterval: 1.1)
+        let outside = "# Doc\n\nA paragraph, rewritten elsewhere.\n"
+        try outside.write(to: url, atomically: true, encoding: .utf8)
+
+        var refused = false
+        do {
+            _ = try undo(&stack)
+        } catch {
+            refused = true
+            check("and says why", (error as? LocalizedError)?.errorDescription?
+                .contains("changed on disk") == true,
+                  (error as? LocalizedError)?.errorDescription ?? "\(error)")
+        }
+        check("undo refuses when the file moved on", refused)
+        check("the outside edit survives", read(url) == outside, String(read(url).prefix(60)))
+
+        print("▸ but our own writing is not an outside edit")
+        let mine = fixture("start\n")
+        var ours = UndoStack()
+        record(&ours, "Comment", on: mine) {
+            try? "start, commented\n".write(to: mine, atomically: true, encoding: .utf8)
+        }
+        var worked = false
+        do { worked = try undo(&ours) } catch { check("our own change undoes cleanly", false, "\(error)") }
+        check("our own change undoes cleanly", worked)
+        check("leaving the file as it started", read(mine) == "start\n", read(mine))
+    }
+
+    // MARK: - The same thing, through the window that people actually use
+
+    /// The model tests above prove the stack writes where it should. This one
+    /// proves the window is wired to it: a real comment, a real navigation, and
+    /// the real ⌘Z selector. It is the reported bug, start to finish.
+    static func theWholeWayThroughTheWindow() throws {
+        print("▸ through the window: comment on A, open B, press undo")
+
+        let a = fixture("# A\n\nThe first document.\n", named: "A.md")
+        let b = fixture("# B\n\nThe second document, which must survive.\n", named: "B.md")
+        let aBefore = read(a)
+        let bBefore = read(b)
+
+        let window = DocumentWindowController(url: a)
+        window.window?.setFrameOrigin(NSPoint(x: -6_000, y: 0))
+        window.showWindow(nil)
+        spin(0.8)
+
+        // A comment about the document needs no selection, so this is the whole
+        // write path — snapshot, insert, seal — with nothing stubbed.
+        window.composingFileNote = true
+        window.saveComment("A note on the whole thing.", colour: .standard)
+        spin(0.6)
+        check("the comment went into A", read(a) != aBefore)
+
+        // Follow a link, or click the sibling in the sidebar. Same call.
+        window.show(b, pushingHistory: true)
+        spin(0.6)
+        check("the window is showing B now", window.url == b)
+
+        // ⌘Z.
+        window.undoComment(nil)
+        spin(0.6)
+
+        check("B is exactly as it was", read(b) == bBefore, String(read(b).prefix(60)))
+        check("and A is back to before the comment", read(a) == aBefore, String(read(a).prefix(60)))
+
+        window.close()
+    }
+
+    /// The window and its WebView need a run loop to get anything done.
+    static func spin(_ seconds: TimeInterval) {
+        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+    }
+}

--- a/release.sh
+++ b/release.sh
@@ -59,6 +59,12 @@ if [ "${1:-}" != "--force" ]; then
 		&& /tmp/imark-release-test >/dev/null || die "the comment tests failed"
 	node Support/test-export.mjs >/dev/null 2>&1 || die "the export test failed"
 	node Support/test-notes.mjs >/dev/null 2>&1 || die "the note anchoring tests failed"
+	swift build >/dev/null 2>&1 \
+		&& swiftc -parse-as-library -I .build/debug/Modules \
+			$(find Sources/Imark -name '*.swift' ! -name main.swift) \
+			$(find Sources/ImarkRender -name '*.swift') \
+			Support/test-undo.swift -o /tmp/imark-release-undo >/dev/null 2>&1 \
+		&& /tmp/imark-release-undo >/dev/null || die "the undo tests failed"
 	swiftc -parse-as-library Sources/Imark/Updates.swift Sources/Imark/Settings.swift \
 		Sources/Imark/NoteColour.swift Support/test-update.swift \
 		-o /tmp/imark-release-update >/dev/null 2>&1 \


### PR DESCRIPTION
Reported on Discord by **t_var_s**, found with GPT. Both halves check out, and both lose data.

## What happened

Comment on a file, follow a link to another one in the same window, press ⌘Z — and the first file's entire contents were written over the second.

The undo stack held the text and a label, but not the file it came from:

```swift
private var undoStack: [(text: String, what: String)] = []   // no url
...
url = target                                                 // navigating swaps it
...
try Comments.restore(last.text, to: url)                     // writes to whichever is showing
```

The stack was never cleared on navigation, and the menu stayed enabled, still offering *Undo Comment* for a document you were no longer looking at.

The second sequence: comment, edit the same file in another editor, let Imark reload, then undo. `restore` skipped the staleness check that every other write in the app performs — deliberately, on the grounds that the caller took the snapshot and is asking for it back. That holds until something else writes in between, and then undo is a way to erase somebody's work.

## The fix

Both come from the same place: a snapshot is not just text, it is text belonging to a particular file at a particular moment. `UndoStack` now carries all three, and the window cannot name a file at all.

```swift
// before
try Comments.restore(last.text, to: url)   // which url? whatever is on screen

// after
try undoStack.undoLast()                   // no argument left to get wrong
```

`restore` takes a stamp and refuses when the file has moved on, using the `Failure.fileChanged` that already existed for every other write.

## Tests

`Support/test-undo.swift`, 25 checks: writing, editing and deleting all coming back; two undos in a row; an empty stack; the ten-entry cap; a failed write leaving nothing behind; the menu's label; the right file; the other file untouched; an outside edit refused; and our own write not being mistaken for one.

The last four drive a real `DocumentWindowController` offscreen — a real comment through the normal write path, the navigation the sidebar uses, and the selector ⌘Z fires. With the old behaviour restored, that test fails with:

```
FAIL B is exactly as it was — # A
```

`test-comments` gained the case it never had: restoring over an outside write is refused.

Three members of the controller went from `private` to internal so the end-to-end test can drive it, each with a comment saying so. The target is an executable, so this is not public API.

## One thing the tests caught in the fix itself

Consecutive undos broke. Restoring moves the file's timestamp, so the entry underneath read its own predecessor as somebody else's edit and refused — undo would have worked exactly once. Re-stamping the next entry after a successful restore fixes it, and there is a test.

## Also

A sweep of every write to a user's document: `restore` was the only one without a check. The comment export writes to a new file the user picks in a save panel, which is fine.

All nine suites pass.