### PR TITLE
The answer goes to the review you are looking at

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,27 @@ The renderer lives in `renderer/` and is bundled with esbuild; `plugin/` is the
 single source for the agent files, copied into the app at build time. Editing
 the copy inside `Imark.app` changes nothing in the repo.
 
+## The review handshake: test the second round
+
+Everything about a review passes through `~/.imark/pending`, and that directory
+is the only state in Imark that outlives the thing that made it. A review that
+is never answered — the session closed, the process killed — leaves its request
+there, and 0.2.2 shipped an app that answered the leftover instead of the
+review the reviewer was looking at. The agent waited four hours for a decision
+that had already been made. Every suite passed: all of them reviewed a clean
+document once.
+
+So a change to `Review.swift` or to the handshake in `plugin/scripts/imark.mjs`
+is not tested until it is tested **twice over the same document, with a
+leftover in the directory**. Three cases in `Support/test-review.sh` hold that
+line — the abandoned round, the interrupted one, the sweep — and a fourth
+belongs there before the next one gets fixed.
+
+The one step no suite reaches is the press itself: a synthetic click needs
+accessibility permission a terminal does not have. Approve, Send Back, and
+closing the window without deciding have to be tried by hand, in a build, on a
+real review, before a release goes out.
+
 ## What this is not
 
 - **Not an editor.** Imark reads. Comments are the one thing it writes, and that

--- a/README.md
+++ b/README.md
@@ -250,10 +250,10 @@ out — with no server, no port and nothing installed on the other side. The fil
 is the whole bridge.
 
 <p align="center">
-  <img src=".github/assets/review.gif" width="720" alt="Pressing Request Changes in the toolbar, and the agent picking the notes up in the terminal">
+  <img src=".github/assets/review.gif" width="720" alt="Pressing Send Back in the toolbar, and the agent picking the notes up in the terminal">
 </p>
 
-<p align="center"><em>Request Changes, and the agent reads your notes back.</em></p>
+<p align="center"><em>Send Back, and the agent reads your notes back.</em></p>
 
 [`plugin/`](plugin/README.md) is a Claude Code plugin that does exactly that:
 

--- a/Sources/Imark/DocumentToolbar.swift
+++ b/Sources/Imark/DocumentToolbar.swift
@@ -160,7 +160,10 @@ extension DocumentWindowController: NSToolbarDelegate {
             // The palette's own red, the same one you can paint a note with.
             // Borrowing GitHub's would have put a colour in the window that
             // appears nowhere else in the app.
-            return reviewButton(identifier, title: "Request Changes",
+            // "Send Back", not GitHub's "Request Changes": this is a document,
+            // not a diff, and the button is not filing a review — it is handing
+            // the document back to whoever wrote it, with your notes on it.
+            return reviewButton(identifier, title: "Send Back",
                                 symbol: "arrow.uturn.backward",
                                 tip: "Send your notes back and hold the work",
                                 tint: NoteColour.red.colour,
@@ -200,7 +203,7 @@ extension DocumentWindowController: NSToolbarDelegate {
         // said instead of inviting you to say it twice.
         if Review.decision(for: url) != nil {
             button.isEnabled = false
-            button.title = filled ? "Approved" : "Changes Requested"
+            button.title = filled ? "Approved" : "Sent Back"
         }
 
         let item = NSToolbarItem(itemIdentifier: identifier)
@@ -275,15 +278,46 @@ extension DocumentWindowController: NSToolbarDelegate {
         // nothing about what to change, which is the one outcome nobody wants.
         guard noteCount > 0 else {
             let alert = NSAlert()
-            alert.messageText = "Request changes with no notes?"
+            alert.messageText = "Send it back with no notes?"
             alert.informativeText = "You haven't commented on anything. "
                 + "The agent will be told to revise without being told what to change."
-            alert.addButton(withTitle: "Request Changes Anyway")
+            alert.addButton(withTitle: "Send Back Anyway")
             alert.addButton(withTitle: "Cancel")
             guard alert.runModal() == .alertFirstButtonReturn else { return }
             return finishReview(.requestChanges)
         }
         finishReview(.requestChanges)
+    }
+
+    /// Closing the window is not an answer, and somebody is waiting for one.
+    ///
+    /// A silent close used to leave the agent on the other end blocked on a
+    /// window that was no longer on screen — until the wait timed out, four
+    /// hours later. So the window asks on the way out, and closing is not one
+    /// of the things it offers: you answer, or you go back to reviewing.
+    @objc func windowShouldClose(_ sender: NSWindow) -> Bool {
+        guard Review.isReview(url), Review.decision(for: url) == nil else { return true }
+
+        let alert = NSAlert()
+        alert.messageText = "Finish this review?"
+        alert.informativeText = "Something is waiting for your answer, and closing "
+            + "the window doesn't give it one."
+        // First is the default and the one Escape lands on: the safe way out of a
+        // dialogue nobody asked for is back to the document.
+        alert.addButton(withTitle: "Keep Reviewing")
+        alert.addButton(withTitle: "Approve")
+        alert.addButton(withTitle: "Send Back")
+
+        switch alert.runModal() {
+        case .alertSecondButtonReturn: finishReview(.approve)
+        // Through the button's own action, so sending back with nothing
+        // commented still gets the warning it gets from the toolbar.
+        case .alertThirdButtonReturn: sendReviewBack(nil)
+        default: break
+        }
+        // Either way this close does not happen: deciding closes the window
+        // itself a moment later, once the button has shown what was pressed.
+        return false
     }
 
     private func finishReview(_ decision: Review.Decision) {

--- a/Sources/Imark/Review.swift
+++ b/Sources/Imark/Review.swift
@@ -36,12 +36,20 @@ enum Review {
     /// before cleaning up. One still unanswered always wins over it — otherwise
     /// the leftovers of a dead review would show a fresh one as already decided,
     /// and the buttons the reviewer needs would never appear.
+    ///
+    /// Between two unanswered requests for the same file the newest wins, and it
+    /// has to be the newest: a review the reviewer walked away from leaves its
+    /// request behind unanswered, and the whoever-sorts-first version handed the
+    /// decision to that corpse — the agent actually waiting was never told
+    /// anything and the window looked answered. The one that opened the window
+    /// in front of the reviewer is the last one to have asked.
     private static func request(for url: URL) -> URL? {
         guard let names = try? FileManager.default
             .contentsOfDirectory(atPath: pendingDir.path) else { return nil }
         let target = url.resolvingSymlinksInPath().path
-        var answered: URL?
-        for name in names.sorted()
+        var waiting: (file: URL, at: String)?
+        var answered: (file: URL, at: String)?
+        for name in names
         where name.hasSuffix(".json") && !name.hasSuffix(".decision.json") {
             let file = pendingDir.appendingPathComponent(name)
             guard let data = try? Data(contentsOf: file),
@@ -49,10 +57,17 @@ enum Review {
                   let requested = payload["file"] as? String,
                   URL(fileURLWithPath: requested).resolvingSymlinksInPath().path == target
             else { continue }
-            if !FileManager.default.fileExists(atPath: answer(to: file).path) { return file }
-            if answered == nil { answered = file }
+            // The stamp the script wrote when it asked. All of them are UTC in
+            // the same shape, so later reads as greater; a request without one
+            // is older than anything that has one, never newer.
+            let candidate = (file, payload["at"] as? String ?? "")
+            if FileManager.default.fileExists(atPath: answer(to: file).path) {
+                if answered == nil || candidate.1 > answered!.at { answered = candidate }
+            } else if waiting == nil || candidate.1 > waiting!.at {
+                waiting = candidate
+            }
         }
-        return answered
+        return (waiting ?? answered)?.file
     }
 
     private static func answer(to request: URL) -> URL {

--- a/Support/test-review.sh
+++ b/Support/test-review.sh
@@ -169,6 +169,107 @@ check "the fresh review keeps waiting"         "$out" "still waiting"
 check "and the real decision still lands"      "$out" "DID NOT APPROVE"
 refute "the ghost approval never surfaces"     "$out" "APPROVED — the reviewer accepted this"
 
+# Shipped in 0.2.2 and found by pressing the button: a round nobody finished
+# leaves an unanswered request behind, and the app answered whichever sorted
+# first. The reviewer pressed Send Back, the corpse got the answer, and the
+# agent actually waiting was never told anything.
+echo "▸ an abandoned round cannot swallow the answer"
+abandoned() {
+  local dir; dir="$(mktemp -d)"
+  cd "$dir"
+  export IMARK_PENDING_DIR="$dir/pending"
+  mkdir -p "$IMARK_PENDING_DIR"
+  printf '# Plan\n\nA paragraph that is going to be reviewed.\n' > SPEC.md
+
+  IMARK_TEST_NO_OPEN=1 node "$OLDPWD/plugin/scripts/imark.mjs" review SPEC.md > out.txt 2>&1 &
+  local pid=$!
+  local request; request="$(wait_for "$IMARK_PENDING_DIR/*.json")"
+  if [[ -z "$request" ]]; then
+    kill "$pid" 2>/dev/null; echo "the request was never announced"
+    unset IMARK_PENDING_DIR; cd "$OLDPWD"; rm -rf "$dir"; return
+  fi
+
+  # The corpse of an earlier round, dropped in after the live one is already
+  # waiting — a script that was killed outright, so it never withdrew and the
+  # live review never saw it to clear it. Older stamp, and a name that sorts
+  # before anything the script rolls: the version that took whichever came
+  # first alphabetically handed this one the answer.
+  cat > "$IMARK_PENDING_DIR/0000deadbeef.json" <<EOF
+{ "file": "$(pwd)/SPEC.md", "at": "2026-08-13T21:31:17.392Z", "by": "Claude Code" }
+EOF
+
+  {
+    echo
+    echo '<!-- imark quote="going to be reviewed" by="miguel" at="2026-08-13T21:38Z"'
+    echo 'This needs a number.'
+    echo '-->'
+  } >> SPEC.md
+  /tmp/imark-decide "$(pwd)/SPEC.md" request-changes 1 > /dev/null
+
+  # Four polls: if it were going to wake up it would have by now.
+  for _ in $(seq 1 8); do kill -0 "$pid" 2>/dev/null || break; sleep 0.25; done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+    echo "STILL-WAITING: the answer went somewhere else"
+  else
+    wait "$pid" 2>/dev/null; cat out.txt
+  fi
+  unset IMARK_PENDING_DIR; cd "$OLDPWD"; rm -rf "$dir"
+}
+out="$(abandoned)"
+refute "the live review is not left hanging"    "$out" "STILL-WAITING"
+check "it gets the decision"                    "$out" "DID NOT APPROVE"
+check "with the note that was written"          "$out" "This needs a number"
+
+# The other half of the same bug: the round that leaves the corpse behind.
+echo "▸ an interrupted review takes its request with it"
+interrupted() {
+  local dir; dir="$(mktemp -d)"
+  cd "$dir"
+  export IMARK_PENDING_DIR="$dir/pending"
+  printf '# Plan\n\nA paragraph that is going to be reviewed.\n' > SPEC.md
+
+  IMARK_TEST_NO_OPEN=1 node "$OLDPWD/plugin/scripts/imark.mjs" review SPEC.md > out.txt 2>&1 &
+  local pid=$!
+  local request; request="$(wait_for "$IMARK_PENDING_DIR/*.json")"
+  # Closing the session, or Ctrl-C in the terminal.
+  kill -TERM "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null
+  sleep 0.25
+  local left; left="$(ls "$IMARK_PENDING_DIR" 2>/dev/null)"
+  [[ -n "$left" ]] && echo "LEFTOVER: $left"
+  unset IMARK_PENDING_DIR; cd "$OLDPWD"; rm -rf "$dir"
+}
+refute "nothing is left for the app to answer"  "$(interrupted)" "LEFTOVER"
+
+# And the belt to that pair of braces: whatever a killed round did leave, the
+# next review of the same document takes down before it opens the window.
+echo "▸ a new round clears the last one's leftovers"
+sweeps() {
+  local dir; dir="$(mktemp -d)"
+  cd "$dir"
+  export IMARK_PENDING_DIR="$dir/pending"
+  mkdir -p "$IMARK_PENDING_DIR"
+  printf '# Plan\n\nA paragraph that is going to be reviewed.\n' > SPEC.md
+  cat > "$IMARK_PENDING_DIR/0000deadbeef.json" <<EOF
+{ "file": "$(pwd)/SPEC.md", "at": "2026-08-13T21:31:17.392Z", "by": "Claude Code" }
+EOF
+  # A request for somebody else's document, which is none of our business.
+  cat > "$IMARK_PENDING_DIR/0000cafe0000.json" <<EOF
+{ "file": "$(pwd)/OTHER.md", "at": "2026-08-13T21:31:17.392Z", "by": "Claude Code" }
+EOF
+
+  IMARK_TEST_NO_OPEN=1 node "$OLDPWD/plugin/scripts/imark.mjs" review SPEC.md > out.txt 2>&1 &
+  local pid=$!
+  sleep 1
+  ls "$IMARK_PENDING_DIR" | sed 's/^/PENDING: /'
+  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+  unset IMARK_PENDING_DIR; cd "$OLDPWD"; rm -rf "$dir"
+}
+out="$(sweeps)"
+refute "the corpse for this document is gone"   "$out" "PENDING: 0000deadbeef.json"
+check "another document's review is untouched"  "$out" "PENDING: 0000cafe0000.json"
+
 echo "▸ the plan-mode hook"
 
 hook() {   # hook <on|off> <decision> → prints the JSON Claude Code reads

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -39,7 +39,7 @@ window:
 | | |
 |---|---|
 | **Approve** | the agent carries on, with any notes you left |
-| **Request Changes** | the agent gets every note and revises instead |
+| **Send Back** | the agent gets every note and revises instead |
 
 Your notes are written into the document, exactly as if you had commented on it
 outside a review — they stay there, and they travel with the file. When the

--- a/plugin/commands/imark-review.md
+++ b/plugin/commands/imark-review.md
@@ -21,7 +21,7 @@ notes are written into the document as `<!-- imark … -->` blocks and stay
 there; they travel with the file. Content piped on stdin, or several files at
 once, gets a temporary stand-in document instead, cleaned up afterwards.
 
-The command **blocks** until the user presses Approve or Request Changes in the
+The command **blocks** until the user presses Approve or Send Back in the
 app. That is expected and can take a long time: do not interrupt it, do not put
 a timeout on it, and do not ask whether they are done.
 

--- a/plugin/scripts/imark.mjs
+++ b/plugin/scripts/imark.mjs
@@ -236,8 +236,8 @@ const DECISION = `
 
 ## Decision
 
-**Approve** and **Request Changes**, at the top of the window, end this review.
-*Request Changes* hands the agent everything you commented on; *Approve* lets it
+**Approve** and **Send Back**, at the top of the window, end this review.
+*Send Back* hands the agent everything you commented on; *Approve* lets it
 carry on.
 
 Comment wherever you like until then — nothing you write decides anything.
@@ -343,9 +343,35 @@ function pendingDir() {
   return dir
 }
 
+/**
+ * The requests an earlier round left behind for this same file.
+ *
+ * A review nobody finished — the session ended, the agent was interrupted,
+ * the terminal went — leaves its request on disk with no decision beside it,
+ * and the app cannot tell that corpse from somebody actually waiting. Two of
+ * them for one document is how a decision went to a script that was no longer
+ * listening while the live one waited for four hours. The app now answers the
+ * newest, and this clears the rest so there is nothing to be confused by.
+ */
+function forgetEarlierRequests(dir, target) {
+  const resolved = fs.realpathSync(target)
+  for (const name of fs.readdirSync(dir)) {
+    if (!name.endsWith('.json') || name.endsWith('.decision.json')) continue
+    const file = path.join(dir, name)
+    try {
+      const payload = JSON.parse(fs.readFileSync(file, 'utf8'))
+      if (!payload.file) continue
+      if (fs.realpathSync(payload.file) !== resolved) continue
+      fs.rmSync(file, { force: true })
+      fs.rmSync(path.join(dir, `${name.slice(0, -'.json'.length)}.decision.json`), { force: true })
+    } catch { /* unreadable, or gone while we looked: not ours to keep */ }
+  }
+}
+
 /** Announce to the app that opening `target` is a review, not a read. */
 function requestReview(target) {
   const dir = pendingDir()
+  forgetEarlierRequests(dir, target)
   for (let attempt = 0; attempt < 3; attempt++) {
     const nonce = crypto.randomBytes(6).toString('hex')
     const file = path.join(dir, `${nonce}.json`)
@@ -364,6 +390,25 @@ function requestReview(target) {
 function withdraw(request) {
   fs.rmSync(request.file, { force: true })
   fs.rmSync(request.decision, { force: true })
+}
+
+/**
+ * Take the request down if this process is killed rather than answered.
+ *
+ * A review is a long wait, and the thing waiting is a coding agent inside a
+ * session somebody can close at any moment. Withdrawing only on the happy path
+ * meant every abandoned round left a request on disk for the app to answer
+ * later instead of the live one.
+ */
+function withdrawWhenKilled(request) {
+  // The codes a shell reports for a signal, so being killed still reads as
+  // being killed rather than as a review that finished.
+  for (const [signal, code] of [['SIGINT', 130], ['SIGTERM', 143], ['SIGHUP', 129]]) {
+    process.once(signal, () => {
+      withdraw(request)
+      process.exit(code)
+    })
+  }
 }
 
 /**
@@ -513,6 +558,7 @@ async function cmdReview(argv) {
   }
 
   const request = requestReview(target)
+  withdrawWhenKilled(request)
   try {
     openInImark(target)
   } catch (error) {
@@ -521,7 +567,7 @@ async function cmdReview(argv) {
     throw error
   }
   if (!wait) { say(`Opened in Imark: ${target}`); return }
-  say(`Opened in Imark: ${target}\nWaiting for Approve or Request Changes in the window…`)
+  say(`Opened in Imark: ${target}\nWaiting for Approve or Send Back in the window…`)
 
   const result = await waitForDecision(target, request)
   withdraw(request)
@@ -553,6 +599,7 @@ async function cmdPlanHook() {
   // the one review that still goes through a stand-in document.
   const file = writeEphemeral({ title: 'Plan', body: plan })
   const request = requestReview(file)
+  withdrawWhenKilled(request)
   try { openInImark(file) } catch (error) {
     process.stderr.write(`imark: ${error.message}\n`)
     withdraw(request)


### PR DESCRIPTION
Fixes #3.

A review that nobody finished leaves its request in `~/.imark/pending`, and the app answered whichever of them sorted first. On a second round over the same document that was the abandoned one: the window closed saying it was done, and the agent actually waiting was never told anything.

**The app** answers the newest request for a document now, which is the one that opened the window in front of the reviewer.

**The script** takes its request down when it is killed, not only when it is answered, and clears what an earlier round left behind for the same file before opening a new one. Either half alone would only move the hole.

**Closing the window** without deciding left the same four hour wait with nothing to explain it. It asks on the way out now, and closing is not one of the things it offers.

**The button says Send Back.** Request Changes is GitHub's word for a diff; this is a document going back with notes on it.

## Tests

Three cases in `Support/test-review.sh`, all failing before this: the abandoned round that used to swallow the answer, the interrupted one that used to leave the corpse, and the sweep that clears what is left. All seven suites pass.

Every suite passed on 0.2.2 as well, because every one of them reviewed a clean document once. `CONTRIBUTING.md` now says what that missed: the handshake directory is the only state in Imark that outlives what made it, so it is not tested until it is tested twice over the same document, with a leftover in the directory.

The press itself is still out of reach of any suite. Send Back, Approve and closing the window were tried by hand on a real review before this went up.