### PR TITLE
Comment on the item, not on the list it is in

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ node Support/test-notes.mjs
 node Support/test-export.mjs
 node Support/test-math.mjs
 swift Support/test-plus.swift
+swift Support/test-pieces.swift
 ```
 
 The rest of the suites, the ones a release runs:
@@ -33,6 +34,7 @@ The rest of the suites, the ones a release runs:
 swiftc -parse-as-library Sources/Imark/Comments.swift Sources/Imark/NoteColour.swift \
   Support/test-comments.swift -o /tmp/imark-test && /tmp/imark-test
 Support/test-setup.sh
+Support/test-cli.sh
 ```
 
 ## Where things are

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ macOS 14 or later. Imark tells you when a newer version exists — once per rele
 
 To make it the default for `.md`: launch it with no document open and click **Make Imark the default for .md**, or use the same item in the **Imark** menu. Once it is the default, both quietly disappear.
 
+### From a terminal
+
+**Imark ▸ Install the imark Command…** links `imark` into `/usr/local/bin`, or
+into `~/.local/bin` when that first one belongs to root — the alert says which,
+before it writes anything.
+
+```bash
+imark notes.md            # opens it in the copy already running
+imark notes notes.md      # the notes somebody left in it, as text
+```
+
+A document already open comes forward instead of opening twice. This is separate
+from making Imark the default for `.md` on purpose: `open notes.md` should still
+go to your editor.
+
 ## Editing
 
 The toolbar has one switch: an eye and a pencil. The eye is the app you know —
@@ -112,6 +127,12 @@ Select a phrase, press the speech bubble, write, press `↵`. The quoted words g
 underlined, a dot appears in the margin, and clicking either opens the note. Pick
 one of five colours while writing it, or change it later. The card carries **Edit**
 and **Delete**, and `⌘Z` undoes any of it — writing, editing or deleting.
+
+Without a selection there is a **+** in the margin, level with whatever the
+pointer is beside. On a list or a table it offers the **item or the cell** you
+are level with rather than the whole block — an agent's twenty-item list is
+twenty things to disagree with, not one — and the note quotes that item, so the
+file says which one it meant to anyone who reads it without the app.
 
 The note is stored **inside the `.md` file**, as an HTML comment:
 
@@ -206,6 +227,7 @@ and tells you the rest were left alone.
 | The `.md` you are reading | when you save an edit or a comment. Written to a temporary file beside it and moved into place; it refuses to save at all if the document changed on disk since Imark read it |
 | `~/.imark/pending` | while an agent is waiting on a review: which document, and what you decided. Deleted when the agent reads it |
 | `~/Library/Preferences/pt.miguelsilva.imark.plist` | your settings — theme, text size, width, the update check |
+| `/usr/local/bin/imark`, or `~/.local/bin/imark` | only if you ask for the `imark` command. One symlink into the app, named in the alert first. Deleting it undoes it |
 | `~/.claude/skills`, `~/.codex/skills`, … | only if you accept the offer to set up your coding agents, and only the files the alert names. A new version rewrites those same files once, on its first launch, unless you edited them |
 | The network | one request a day to `api.github.com` asking whether a newer version exists. A version number travels, nothing of yours does, and Settings turns it off |
 

--- a/Sources/Imark/AppDelegate.swift
+++ b/Sources/Imark/AppDelegate.swift
@@ -206,12 +206,60 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Greys out the menu item once Imark already owns .md — offering to do
-    /// something that is already done is just noise.
+    /// something that is already done is just noise. Same for the command,
+    /// which says where it went the first time and has nothing to add after.
     func validateMenuItem(_ item: NSMenuItem) -> Bool {
         if item.action == #selector(makeDefaultHandler(_:)) {
             return !MarkdownType.imarkIsDefault
         }
+        if item.action == #selector(installCommandLineTool(_:)) {
+            return !CommandLineTool.isInstalled
+        }
         return true
+    }
+
+    /// Puts `imark` on the PATH, after saying exactly which file it is about to
+    /// write and where. It writes outside Imark's own container, which is
+    /// something to ask about rather than announce afterwards.
+    @objc func installCommandLineTool(_ sender: Any?) {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let target = CommandLineTool.destination.path
+        let shown = target.replacingOccurrences(of: home, with: "~")
+        let directory = CommandLineTool.destination.deletingLastPathComponent().path
+            .replacingOccurrences(of: home, with: "~")
+
+        let alert = NSAlert()
+        alert.messageText = "Install the imark command?"
+        alert.informativeText = [
+            "This links:",
+            "",
+            shown,
+            "",
+            "`imark notes.md` then opens a document in the copy of Imark you are "
+                + "already running, and brings it forward if it is open. Deleting "
+                + "that one link undoes it.",
+            CommandLineTool.isOnPath ? "" :
+                "\nYour shell does not look in \(directory) yet. Add it to PATH "
+                + "and open a new terminal.",
+        ].joined(separator: "\n")
+        alert.addButton(withTitle: "Install")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        do {
+            try CommandLineTool.install()
+            let done = NSAlert()
+            done.messageText = "The imark command is installed."
+            done.informativeText = CommandLineTool.isOnPath
+                ? "Try `imark notes.md` in a terminal."
+                : "It is at \(shown). Add \(directory) to your PATH to use it by name."
+            done.runModal()
+        } catch {
+            let failure = NSAlert()
+            failure.messageText = "Imark couldn't install the command."
+            failure.informativeText = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            failure.runModal()
+        }
     }
 
     @objc func makeDefaultHandler(_ sender: Any?) {

--- a/Sources/Imark/AppDelegate.swift
+++ b/Sources/Imark/AppDelegate.swift
@@ -238,9 +238,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "`imark notes.md` then opens a document in the copy of Imark you are "
                 + "already running, and brings it forward if it is open. Deleting "
                 + "that one link undoes it.",
-            CommandLineTool.isOnPath ? "" :
-                "\nYour shell does not look in \(directory) yet. Add it to PATH "
-                + "and open a new terminal.",
+            CommandLineTool.mayNeedPathSetup
+                ? "\nIf your terminal cannot find it, add \(directory) to PATH "
+                    + "and open a new terminal."
+                : "",
         ].joined(separator: "\n")
         alert.addButton(withTitle: "Install")
         alert.addButton(withTitle: "Cancel")
@@ -250,9 +251,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             try CommandLineTool.install()
             let done = NSAlert()
             done.messageText = "The imark command is installed."
-            done.informativeText = CommandLineTool.isOnPath
-                ? "Try `imark notes.md` in a terminal."
-                : "It is at \(shown). Add \(directory) to your PATH to use it by name."
+            done.informativeText = CommandLineTool.mayNeedPathSetup
+                ? "Try `imark notes.md` in a terminal. If it cannot find the command, "
+                    + "add \(directory) to PATH and open a new terminal."
+                : "Try `imark notes.md` in a terminal."
             done.runModal()
         } catch {
             let failure = NSAlert()

--- a/Sources/Imark/CommandLineTool.swift
+++ b/Sources/Imark/CommandLineTool.swift
@@ -46,22 +46,35 @@ enum CommandLineTool {
         test.map { URL(fileURLWithPath: $0) } ?? FileManager.default.homeDirectoryForCurrentUser
     }
 
-    /// Installed, and installed by us: a link that points into some other copy
-    /// of Imark is still this command, but a file of somebody's own that
-    /// happens to be called `imark` is not ours to report on or overwrite.
+    /// Installed into this copy of Imark. A link to another copy is ours to
+    /// repair, but it is not working for the app whose menu is being used now.
     static var isInstalled: Bool {
-        guard let target = try? FileManager.default
-            .destinationOfSymbolicLink(atPath: destination.path)
-        else { return false }
-        return target.hasSuffix("/Contents/Resources/imark")
+        guard let linked = linkedSource, let source else { return false }
+        return linked.standardizedFileURL == source.standardizedFileURL
     }
 
-    /// Whether the shell would find it, which is the only thing that makes an
-    /// installed command useful. `/usr/local/bin` always would; a directory
-    /// under the home directory is on the PATH only if somebody put it there.
-    static var isOnPath: Bool {
-        let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
-        return path.split(separator: ":").contains { $0 == destination.deletingLastPathComponent().path }
+    /// A command under the home directory may need one line in the shell's
+    /// PATH. A GUI app does not inherit the shell's startup files, so it cannot
+    /// truthfully claim whether that line is already there; it can only give
+    /// the advice when it may be needed.
+    static var mayNeedPathSetup: Bool {
+        destination.path.hasPrefix(home.appendingPathComponent(".local/bin").path)
+    }
+
+    /// The destination of the installed link as an absolute URL, including a
+    /// relative link somebody may have made by hand.
+    private static var linkedSource: URL? {
+        guard let raw = try? FileManager.default
+            .destinationOfSymbolicLink(atPath: destination.path)
+        else { return nil }
+        if raw.hasPrefix("/") { return URL(fileURLWithPath: raw) }
+        return destination.deletingLastPathComponent().appendingPathComponent(raw)
+    }
+
+    /// A link installed by any copy of Imark is safe to repair. A regular file
+    /// or a link to another command is somebody else's and remains untouched.
+    private static var isManagedLink: Bool {
+        linkedSource?.path.hasSuffix("/Contents/Resources/imark") == true
     }
 
     enum Failure: LocalizedError {
@@ -90,8 +103,8 @@ enum CommandLineTool {
         // Replacing our own link is how an install after moving the app fixes
         // itself. Replacing anything else is taking somebody's file away
         // without asking, so it stops instead.
-        if FileManager.default.fileExists(atPath: target.path) || isInstalled {
-            guard isInstalled else { throw Failure.occupied(target.path) }
+        if FileManager.default.fileExists(atPath: target.path) || linkedSource != nil {
+            guard isManagedLink else { throw Failure.occupied(target.path) }
             try FileManager.default.removeItem(at: target)
         }
         try FileManager.default.createSymbolicLink(at: target, withDestinationURL: source)

--- a/Sources/Imark/CommandLineTool.swift
+++ b/Sources/Imark/CommandLineTool.swift
@@ -1,0 +1,99 @@
+import AppKit
+
+/// `imark` in a terminal: a symlink from a directory on the PATH to the script
+/// inside the app bundle.
+///
+/// A symlink rather than a copy, so the command can never be a version behind
+/// the app it opens documents in — and so removing it is one `rm`, which is
+/// what somebody who installed a command by hand expects to be able to do.
+///
+/// The alternative was making Imark the handler for .md, which turns `open
+/// notes.md` into a review of a file you meant to edit. The two are not the
+/// same offer and this one is the smaller.
+enum CommandLineTool {
+    /// The script in the bundle. It ships with the app; a build that forgot it
+    /// has nothing to link to and the offer is not made.
+    static var source: URL? {
+        if let test = ProcessInfo.processInfo.environment["IMARK_TEST_RESOURCES"] {
+            return URL(fileURLWithPath: test).appendingPathComponent("imark")
+        }
+        return Bundle.main.resourceURL?.appendingPathComponent("imark")
+    }
+
+    /// Where it goes. `/usr/local/bin` is where a command installed by hand on
+    /// a Mac has always gone and is on the PATH of every shell without anybody
+    /// arranging it — but it belongs to root, and asking for an administrator
+    /// password to install a convenience is out of proportion. So: there when
+    /// Homebrew or somebody has already made it writable, and the home
+    /// directory otherwise, where the alert says so and says what to add to
+    /// the PATH if it is not there already.
+    static var destination: URL {
+        let shared = URL(fileURLWithPath: "/usr/local/bin")
+        if test == nil, FileManager.default.isWritableFile(atPath: shared.path) {
+            return shared.appendingPathComponent("imark")
+        }
+        return home.appendingPathComponent(".local/bin/imark")
+    }
+
+    /// Redirected for the test, which installs for real and must not do it in
+    /// the home folder of whoever runs it — nor in /usr/local/bin, which is
+    /// shared with every other program on the machine.
+    private static var test: String? {
+        ProcessInfo.processInfo.environment["IMARK_TEST_HOME"]
+    }
+
+    private static var home: URL {
+        test.map { URL(fileURLWithPath: $0) } ?? FileManager.default.homeDirectoryForCurrentUser
+    }
+
+    /// Installed, and installed by us: a link that points into some other copy
+    /// of Imark is still this command, but a file of somebody's own that
+    /// happens to be called `imark` is not ours to report on or overwrite.
+    static var isInstalled: Bool {
+        guard let target = try? FileManager.default
+            .destinationOfSymbolicLink(atPath: destination.path)
+        else { return false }
+        return target.hasSuffix("/Contents/Resources/imark")
+    }
+
+    /// Whether the shell would find it, which is the only thing that makes an
+    /// installed command useful. `/usr/local/bin` always would; a directory
+    /// under the home directory is on the PATH only if somebody put it there.
+    static var isOnPath: Bool {
+        let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
+        return path.split(separator: ":").contains { $0 == destination.deletingLastPathComponent().path }
+    }
+
+    enum Failure: LocalizedError {
+        case missing
+        case occupied(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missing: "This copy of Imark is missing the command."
+            case .occupied(let path):
+                "There is already something at \(path) that Imark did not put there. "
+                    + "Remove it first, or link the command yourself."
+            }
+        }
+    }
+
+    static func install() throws {
+        guard let source, FileManager.default.fileExists(atPath: source.path) else {
+            throw Failure.missing
+        }
+        let target = destination
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        // Replacing our own link is how an install after moving the app fixes
+        // itself. Replacing anything else is taking somebody's file away
+        // without asking, so it stops instead.
+        if FileManager.default.fileExists(atPath: target.path) || isInstalled {
+            guard isInstalled else { throw Failure.occupied(target.path) }
+            try FileManager.default.removeItem(at: target)
+        }
+        try FileManager.default.createSymbolicLink(at: target, withDestinationURL: source)
+    }
+}

--- a/Sources/Imark/Menu.swift
+++ b/Sources/Imark/Menu.swift
@@ -66,6 +66,12 @@ enum Menu {
             keyEquivalent: ""
         )
         makeDefault.target = NSApp.delegate
+        let commandLine = menu.addItem(
+            withTitle: "Install the imark Command…",
+            action: #selector(AppDelegate.installCommandLineTool(_:)),
+            keyEquivalent: ""
+        )
+        commandLine.target = NSApp.delegate
         menu.addItem(.separator())
         let hide = menu.addItem(withTitle: "Hide Imark", action: #selector(NSApplication.hide(_:)), keyEquivalent: "h")
         hide.target = NSApp

--- a/Support/Imark-Info.plist
+++ b/Support/Imark-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0.4.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Support/QuickLook-Info.plist
+++ b/Support/QuickLook-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0.4.0</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Support/bump.sh
+++ b/Support/bump.sh
@@ -10,6 +10,13 @@
 # when one of them falls behind. So one command writes all four, and the
 # release gate refuses a build where they disagree.
 #
+# The two plists carry the version twice: CFBundleShortVersionString, which is
+# the one people say out loud, and CFBundleVersion, the build number underneath
+# it. Both are written to the same value on purpose. Left alone, the build
+# number stayed at 1 forever, and the About panel — and therefore every bug
+# report copied out of it — read "0.4.0 (1)", where the "(1)" told nobody
+# anything. Equal numbers make macOS show the version on its own.
+#
 # The site needs nothing: it reads the version, the notes and the .dmg size off
 # the GitHub release. These four files are the part no server can work out.
 
@@ -47,6 +54,14 @@ if [ "${1:-}" = "--check" ] || [ $# -eq 0 ]; then
 		[ "$(version_of "$f")" = "$APP" ] || MISMATCH="$MISMATCH $f=$(version_of "$f")"
 	done
 
+	# The build number is only in the plists, and only ever wrong by being
+	# left behind, so it is checked against the version rather than listed
+	# separately.
+	for f in "${FILES[@]:0:2}"; do
+		BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$f")"
+		[ "$BUILD" = "$APP" ] || MISMATCH="$MISMATCH $f(build)=$BUILD"
+	done
+
 	if [ -n "$MISMATCH" ]; then
 		printf '\033[1;31m✗ the app says %s, but:%s\033[0m\n' "$APP" "$MISMATCH" >&2
 		echo "  run Support/bump.sh $APP to bring them into line" >&2
@@ -69,15 +84,24 @@ for f in "${FILES[@]}"; do
 		const text = fs.readFileSync(file, "utf8")
 		// One replacement per file, and it fails loudly rather than writing a
 		// file where the version silently stayed where it was.
-		const plist = /(<key>CFBundleShortVersionString<\/key>\s*<string>)[^<]*(<\/string>)/
-		const json = /("version"\s*:\s*")[^"]*(")/
-		const pattern = plist.test(text) ? plist : json
-		const matches = text.match(new RegExp(pattern.source, "g")) || []
-		if (matches.length !== 1) {
-			console.error(`${file}: expected one version, found ${matches.length}`)
-			process.exit(1)
+		// A plist says it twice — the version and the build number under it —
+		// and both are set to the same string. A manifest says it once.
+		const plist = [
+			/(<key>CFBundleShortVersionString<\/key>\s*<string>)[^<]*(<\/string>)/,
+			/(<key>CFBundleVersion<\/key>\s*<string>)[^<]*(<\/string>)/,
+		]
+		const json = [/("version"\s*:\s*")[^"]*(")/]
+		const patterns = plist[0].test(text) ? plist : json
+		let out = text
+		for (const pattern of patterns) {
+			const matches = out.match(new RegExp(pattern.source, "g")) || []
+			if (matches.length !== 1) {
+				console.error(`${file}: expected one ${pattern.source}, found ${matches.length}`)
+				process.exit(1)
+			}
+			out = out.replace(pattern, `$1${version}$2`)
 		}
-		fs.writeFileSync(file, text.replace(pattern, `$1${version}$2`))
+		fs.writeFileSync(file, out)
 	' "$f" "$VERSION"
 done
 

--- a/Support/imark
+++ b/Support/imark
@@ -1,0 +1,69 @@
+#!/bin/bash
+# The command line half of Imark.
+#
+#   imark                    bring the app up
+#   imark notes.md plan.md   open those, in the app that is already running
+#   imark notes plan.md      the notes somebody left in a file, as text
+#   imark review plan.md     open it for review and wait for the decision
+#
+# Lives inside the app bundle and is installed by symlink, so it always drives
+# the copy of Imark it shipped with — including a dev build, which is why the
+# app is found by walking up from this file rather than by name.
+#
+# Opening files is `open` and nothing more: macOS hands them to the instance
+# that is already running, and Imark brings a document already on screen
+# forward instead of opening it twice. Anything cleverer here would be a second
+# answer to a question the system already answers.
+
+set -euo pipefail
+
+SELF="$0"
+while [ -L "$SELF" ]; do
+	LINK="$(readlink "$SELF")"
+	case "$LINK" in
+		/*) SELF="$LINK" ;;
+		*) SELF="$(dirname "$SELF")/$LINK" ;;
+	esac
+done
+RESOURCES="$(cd "$(dirname "$SELF")" && pwd)"
+APP="$(cd "$RESOURCES/../.." && pwd)"
+AGENT="$RESOURCES/agent/imark.mjs"
+
+usage() {
+	cat <<'USAGE'
+usage: imark [<file.md> …]        open documents in Imark
+       imark notes <file.md>      print the notes left in a file
+       imark review <file.md>     open for review, wait for the decision
+USAGE
+}
+
+case "${1:-}" in
+	-h|--help|help) usage; exit 0 ;;
+	--version)
+		/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Contents/Info.plist"
+		exit 0
+		;;
+	notes|review|plan-hook)
+		# The same script the coding agents are given, so `imark review` from a
+		# terminal and a review asked for by an agent are one code path.
+		command -v node >/dev/null \
+			|| { echo "imark: $1 needs node — install Node.js, or use the app" >&2; exit 1; }
+		exec node "$AGENT" "$@"
+		;;
+	'')
+		exec /usr/bin/open -a "$APP"
+		;;
+	-*)
+		echo "imark: unknown option $1" >&2
+		usage >&2
+		exit 2
+		;;
+esac
+
+# Checked before opening anything: `open` reports a missing file by launching
+# the app with nothing in it, which looks like it worked.
+for file in "$@"; do
+	[ -e "$file" ] || { echo "imark: no such file: $file" >&2; exit 1; }
+done
+
+exec /usr/bin/open -a "$APP" "$@"

--- a/Support/test-cli.sh
+++ b/Support/test-cli.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# The `imark` command: the script itself, and the link that puts it on the PATH.
+#
+#   Support/test-cli.sh
+#
+# Needs an assembled app — the script it links to lives in the bundle. Installs
+# into a throwaway home, never the real one.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+APP="${IMARK_APP:-dist/Imark.app}"
+CLI="$APP/Contents/Resources/imark"
+[ -x "$CLI" ] || { echo "FAIL $CLI is missing — run ./build.sh first"; exit 1; }
+
+failures=0
+check() {
+  if [ "$2" = "0" ]; then echo "OK   $1"; else failures=$((failures + 1)); echo "FAIL $1"; fi
+}
+
+HOME_DIR="$(mktemp -d)"
+trap 'rm -rf "$HOME_DIR"' EXIT
+
+# ------------------------------------------------------------- the script
+
+"$CLI" --help >/dev/null 2>&1; check "--help explains itself" $?
+V="$("$CLI" --version 2>/dev/null)"
+[ -n "$V" ]; check "--version answers with the app's own version" $?
+
+# `open` reports a missing file by launching the app with an empty window, which
+# looks like it worked. The check has to happen here or not at all.
+"$CLI" "$HOME_DIR/not-there.md" >/dev/null 2>&1
+[ $? -ne 0 ]; check "a missing file is an error, not a blank window" $?
+
+"$CLI" --nonsense >/dev/null 2>&1
+[ $? -eq 2 ]; check "an unknown option says so" $?
+
+# Reached through a link, as it always is once installed: the script has to
+# find its own bundle from wherever the link lives.
+ln -s "$(cd "$(dirname "$CLI")" && pwd)/imark" "$HOME_DIR/imark"
+[ "$("$HOME_DIR/imark" --version 2>/dev/null)" = "$V" ]
+check "it finds its app through a symlink" $?
+
+printf '# T\n\nA line.\n\n<!-- imark quote="A line" by="m" at="2026-08-27T10:00Z"\nA note.\n-->\n' \
+  > "$HOME_DIR/doc.md"
+"$CLI" notes "$HOME_DIR/doc.md" 2>/dev/null | grep -q "A note."
+check "notes reaches the agent script in the bundle" $?
+
+# --------------------------------------------------------------- the link
+
+swiftc -parse-as-library Sources/Imark/CommandLineTool.swift Support/test-cli.swift \
+  -o /tmp/imark-cli-test 2>/dev/null || { echo "FAIL did not compile"; exit 1; }
+
+IMARK_TEST_HOME="$HOME_DIR" \
+IMARK_TEST_RESOURCES="$(cd "$(dirname "$CLI")" && pwd)" \
+  /tmp/imark-cli-test
+[ $? -eq 0 ] || failures=$((failures + 1))
+
+echo
+if [ "$failures" -eq 0 ]; then echo "all good"; else echo "$failures failing"; fi
+[ "$failures" -eq 0 ]

--- a/Support/test-cli.swift
+++ b/Support/test-cli.swift
@@ -28,6 +28,7 @@ import Foundation
             check("the first install works", false, "\(error)")
         }
         check("it says so afterwards", CommandLineTool.isInstalled)
+        check("a home install gives conditional PATH advice", CommandLineTool.mayNeedPathSetup)
         check("and it is a link, not a copy",
               (try? files.destinationOfSymbolicLink(atPath: link.path))?
                 .hasSuffix("/Contents/Resources/imark") == true)
@@ -40,6 +41,22 @@ import Foundation
             check("installing again is not an error", CommandLineTool.isInstalled)
         } catch {
             check("installing again is not an error", false, "\(error)")
+        }
+
+        // Moving Imark must not leave a dead command and a greyed-out repair
+        // command. A link into an older copy is ours to replace, but it is not
+        // reported as installed for this copy.
+        try? files.removeItem(at: link)
+        let old = home.appendingPathComponent("Old Imark.app/Contents/Resources/imark")
+        try? files.createDirectory(at: old.deletingLastPathComponent(), withIntermediateDirectories: true)
+        files.createFile(atPath: old.path, contents: Data("#!/bin/sh\n".utf8))
+        try? files.createSymbolicLink(at: link, withDestinationURL: old)
+        check("a link to an older copy needs repair", !CommandLineTool.isInstalled)
+        do {
+            try CommandLineTool.install()
+            check("installing repairs a link to an older copy", CommandLineTool.isInstalled)
+        } catch {
+            check("installing repairs a link to an older copy", false, "\(error)")
         }
 
         // Somebody else's imark is not ours to delete.

--- a/Support/test-cli.swift
+++ b/Support/test-cli.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Installing `imark` on the PATH: where the link goes, what it points at, and
+/// what it refuses to touch.
+///
+/// Compiled and run by Support/test-cli.sh, which gives it a throwaway home.
+@main struct T {
+    static var failures = 0
+
+    static func check(_ name: String, _ ok: Bool, _ detail: String = "") {
+        if ok {
+            print("OK   \(name)")
+        } else {
+            failures += 1
+            print("FAIL \(name)\(detail.isEmpty ? "" : " — \(detail)")")
+        }
+    }
+
+    static func main() {
+        let files = FileManager.default
+        let home = URL(fileURLWithPath: ProcessInfo.processInfo.environment["IMARK_TEST_HOME"]!)
+        let link = CommandLineTool.destination
+
+        check("it goes under the home directory in a test", link.path.hasPrefix(home.path), link.path)
+        check("nothing is installed to begin with", !CommandLineTool.isInstalled)
+
+        do { try CommandLineTool.install() } catch {
+            check("the first install works", false, "\(error)")
+        }
+        check("it says so afterwards", CommandLineTool.isInstalled)
+        check("and it is a link, not a copy",
+              (try? files.destinationOfSymbolicLink(atPath: link.path))?
+                .hasSuffix("/Contents/Resources/imark") == true)
+        check("which runs", files.isExecutableFile(atPath: link.path))
+
+        // Installing twice is how somebody who moved the app repairs the link,
+        // so it replaces its own work without complaining.
+        do {
+            try CommandLineTool.install()
+            check("installing again is not an error", CommandLineTool.isInstalled)
+        } catch {
+            check("installing again is not an error", false, "\(error)")
+        }
+
+        // Somebody else's imark is not ours to delete.
+        try? files.removeItem(at: link)
+        files.createFile(atPath: link.path, contents: Data("#!/bin/sh\n".utf8))
+        check("a file we did not write is not reported as ours", !CommandLineTool.isInstalled)
+        do {
+            try CommandLineTool.install()
+            check("and it is not overwritten", false, "install went ahead anyway")
+        } catch {
+            check("and it is not overwritten", true)
+        }
+        check("the other file is still there", files.fileExists(atPath: link.path))
+
+        print(failures == 0 ? "\nall good" : "\n\(failures) failing")
+        exit(failures == 0 ? 0 : 1)
+    }
+}

--- a/Support/test-pieces.swift
+++ b/Support/test-pieces.swift
@@ -1,0 +1,275 @@
+#!/usr/bin/env swift
+//
+// A note on one list item, or one table cell, in a real web view, off screen.
+//
+//   swift Support/test-pieces.swift
+//
+// Agents write long lists, and a note used to say only "somewhere in this list"
+// — one dot at the top of nineteen items, and a `+` in the margin that offered
+// the whole list or nothing. What is checked here is the pair that fixes it:
+// the `+` offers the item or the cell the pointer is level with, and a note's
+// dot sits down beside the words it quotes rather than at the top of the block.
+//
+// The file is not touched by any of it. A comment written between two list
+// items splits the list in two, so notes still land after the block and the
+// quote is what says which item — which is why the quote the `+` sends matters
+// enough to be checked here.
+
+import AppKit
+import WebKit
+
+let repo = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent()
+let resources = repo.appendingPathComponent("Resources")
+
+// Same stage as test-plus.swift: the page's own CSP only lets the app's scheme
+// load the bundle, and a file:// load cannot satisfy it.
+let stage = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("imark-test-pieces")
+try? FileManager.default.removeItem(at: stage)
+try! FileManager.default.copyItem(at: resources, to: stage)
+let page = stage.appendingPathComponent("index.html")
+var html = try! String(contentsOf: page, encoding: .utf8)
+html = html.replacingOccurrences(
+    of: #"<meta[^>]*Content-Security-Policy[^>]*>"#,
+    with: "",
+    options: [.regularExpression, .caseInsensitive]
+)
+html = html.replacingOccurrences(of: "imark://app/", with: "")
+try! html.write(to: page, atomically: true, encoding: .utf8)
+
+let SCRIPT = """
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const sent = []
+window.webkit = { messageHandlers: { imark: { postMessage: (p) => sent.push(p) } } }
+const results = {}
+const move = (target, x, y) => target.dispatchEvent(
+  new MouseEvent('mousemove', { bubbles: true, clientX: x, clientY: y })
+)
+const plus = () => document.querySelector('.block-plus')
+const lit = () => document.querySelector('.block-target')
+
+// The notes go where the placeholder is: a note belongs to the block above it,
+// so one written under the table would be a note about the table however well
+// its quote matched an item of the list.
+const RAW = [
+  '# Heading',
+  '',
+  '- Item one',
+  '- Item two that should have a comment attached to it',
+  '- Item three',
+  '',
+  '<<after the list>>',
+  '',
+  '| Name | Verdict |',
+  '| --- | --- |',
+  '| alpha | keep |',
+  '| beta | drop |',
+  '| gamma | keep |',
+  '',
+  '<<after the table>>',
+  '',
+  'A closing paragraph.',
+  '',
+].join('\\n')
+
+const strip = (text) => text.replace(/^<<[^>]*>>\\n\\n/gm, '')
+const withNote = (where, lines) =>
+  strip(RAW.replace(`<<${where}>>`, lines.join('\\n')))
+const DOC = strip(RAW)
+
+// 1. A note quoting the second item sits beside that item, not at the top of
+//    the list — and the item, quoted whole, is washed rather than underlined.
+await window.imark.render({
+  markdown: withNote('after the list', [
+    '<!-- imark quote="Item two that should have a comment attached to it"'
+      + ' nth="1" by="miguel" at="2026-08-27T10:00Z"',
+    'This item, and not the other two.',
+    '-->',
+  ]),
+  path: '/tmp/t.md',
+  theme: 'dark',
+})
+await sleep(300)
+
+const item = [...document.querySelectorAll('li')]
+  .find((li) => li.textContent.includes('Item two'))
+results.itemNoteFoundTheItem = !!item
+results.itemIsWashedWhole = !!item?.classList.contains('note-piece')
+const itemDot = document.querySelector('.note-dot')
+const holder = itemDot?.parentElement
+results.itemNoteHasOneDot = document.querySelectorAll('.note-dot').length === 1
+{
+  const want = item.getBoundingClientRect().top - holder.getBoundingClientRect().top
+  const got = Number.parseInt(itemDot.style.top || '0', 10)
+  results.itemDotSitsBesideTheItem = want > 8 && Math.abs(got - (want + 2)) <= 3
+}
+
+// 2. The same for one cell of a table, where the dot cannot live inside the
+//    cell at all: the table scrolls sideways and would clip it.
+await window.imark.render({
+  markdown: withNote('after the table', [
+    '<!-- imark quote="drop" nth="1" by="miguel" at="2026-08-27T10:00Z"',
+    'This verdict.',
+    '-->',
+  ]),
+  path: '/tmp/t.md',
+  theme: 'dark',
+})
+await sleep(300)
+const cell = [...document.querySelectorAll('td')].find((td) => td.textContent.trim() === 'drop')
+const cellDot = document.querySelector('.note-dot')
+results.cellNoteFoundTheCell = !!cell?.querySelector('.note-anchor')
+{
+  const want = cell.getBoundingClientRect().top
+    - cellDot.parentElement.getBoundingClientRect().top
+  const got = Number.parseInt(cellDot.style.top || '0', 10)
+  results.cellDotSitsOnItsOwnRow = want > 8 && Math.abs(got - (want + 2)) <= 3
+}
+
+// 3. Two notes on the same item still stack; two notes on different items do
+//    not, which is the whole point of moving the dot in the first place.
+await window.imark.render({
+  markdown: withNote('after the list', [
+    '<!-- imark quote="Item one" nth="1" by="miguel" at="2026-08-27T10:00Z"',
+    'On the first.',
+    '-->',
+    '',
+    '<!-- imark quote="Item three" nth="1" by="miguel" at="2026-08-27T10:01Z"',
+    'On the third.',
+    '-->',
+  ]),
+  path: '/tmp/t.md',
+  theme: 'dark',
+})
+await sleep(300)
+{
+  const tops = [...document.querySelectorAll('.note-dot')]
+    .map((dot) => Number.parseInt(dot.style.top || '0', 10))
+  results.twoItemsGetTwoHeights = tops.length === 2 && Math.abs(tops[0] - tops[1]) > 12
+}
+
+// 4. The `+`: on the words of an item, the item is what lights up.
+await window.imark.render({ markdown: DOC, path: '/tmp/t.md', theme: 'dark' })
+await sleep(300)
+const third = [...document.querySelectorAll('li')].find((li) => li.textContent.includes('Item three'))
+const thirdBox = third.getBoundingClientRect()
+move(third, thirdBox.left + 20, thirdBox.top + 4)
+await sleep(40)
+results.plusOffersTheItem = lit() === third
+results.plusShowsForTheItem = plus().style.display !== 'none'
+
+// 5. And from out in the margin, level with it, where there is nothing under
+//    the pointer to ask.
+move(document.body, 5, 5)
+await sleep(400)
+move(document.body, thirdBox.left - 60, thirdBox.top + 4)
+await sleep(40)
+results.plusOffersTheItemFromTheMargin = lit() === third
+
+// 6. Pressing it sends the item's own words as the quote — the only thing in
+//    the file that can say which item, since the note goes after the list.
+plus().dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+plus().click()
+await sleep(30)
+{
+  const message = sent.filter((m) => m.type === 'selection').pop()
+  results.itemPlusSendsTheItem = message?.text === 'Item three'
+  results.itemPlusWritesAfterTheList =
+    message?.block?.end === Number(document.querySelector('ul').dataset.line?.split(',')[1])
+}
+
+// 7. The same on a cell, and the copy it sends is the right one: two cells of
+//    this table say "keep", and the note has to find the second.
+const gamma = [...document.querySelectorAll('td')].find((td) => td.previousElementSibling?.textContent === 'gamma')
+const gammaBox = gamma.getBoundingClientRect()
+move(gamma, gammaBox.left + 6, gammaBox.top + 4)
+await sleep(40)
+results.plusOffersTheCell = lit() === gamma
+plus().dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+plus().click()
+await sleep(30)
+{
+  const message = sent.filter((m) => m.type === 'selection').pop()
+  results.cellPlusSendsTheCell = message?.text === 'keep'
+  results.cellPlusCountsTheCopies = message?.occurrence === 2
+}
+
+// 7b. From the margin beside the table, though, the offer is the table. A row
+//     has four cells level with the pointer and choosing one would be a guess.
+move(document.body, 5, 5)
+await sleep(400)
+const table = document.querySelector('table')
+const tableBox = table.getBoundingClientRect()
+move(document.body, tableBox.left - 60, gammaBox.top + 4)
+await sleep(40)
+results.marginBesideATableOffersTheTable = lit() === table
+
+// 8. Nothing changed for a paragraph, which has no pieces in it.
+const para = [...document.getElementById('content').children].find((el) => el.tagName === 'P')
+const paraBox = para.getBoundingClientRect()
+move(document.body, 5, 5)
+await sleep(400)
+move(para, paraBox.left + 20, paraBox.top + 4)
+await sleep(40)
+results.paragraphStillOffersItself = lit() === para
+plus().dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+plus().click()
+await sleep(30)
+results.paragraphPlusStillSendsNoQuote =
+  sent.filter((m) => m.type === 'selection').pop()?.text === ''
+
+return JSON.stringify(results)
+"""
+
+final class Harness: NSObject, WKNavigationDelegate {
+    let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 1_400, height: 1_000))
+    private var window: NSWindow?
+
+    func run() {
+        webView.navigationDelegate = self
+        let window = NSWindow(
+            contentRect: NSRect(x: -6_000, y: 0, width: 1_400, height: 1_000),
+            styleMask: [.borderless], backing: .buffered, defer: false
+        )
+        window.contentView = webView
+        window.orderFrontRegardless()
+        self.window = window
+        webView.loadFileURL(page, allowingReadAccessTo: stage)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            webView.callAsyncJavaScript(SCRIPT, in: nil, in: .page) { result in
+                switch result {
+                case .failure(let error):
+                    FileHandle.standardError.write(Data("js failed: \(error)\n".utf8))
+                    exit(1)
+                case .success(let value):
+                    report(String(describing: value))
+                }
+            }
+        }
+    }
+}
+
+func report(_ json: String) {
+    guard let data = json.data(using: .utf8),
+          let checks = try? JSONSerialization.jsonObject(with: data) as? [String: Bool]
+    else {
+        FileHandle.standardError.write(Data("unreadable response: \(json)\n".utf8))
+        exit(1)
+    }
+    var failed = 0
+    for key in checks.keys.sorted() {
+        let ok = checks[key] == true
+        if !ok { failed += 1 }
+        print("\(ok ? "OK  " : "FAIL ") \(key)")
+    }
+    print(failed == 0 ? "\nall good" : "\n\(failed) failing")
+    exit(failed == 0 ? 0 : 1)
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.prohibited)
+let harness = Harness()
+harness.run()
+app.run()

--- a/build.sh
+++ b/build.sh
@@ -103,6 +103,12 @@ else
 	echo "warning: no icon — run 'swift Support/make-icon.swift'" >&2
 fi
 
+# The shell command, beside the resources it drives. Installed by symlink from
+# the app rather than copied out, so it can never be a version behind the app it
+# opens documents in.
+cp "$ROOT/Support/imark" "$APP/Contents/Resources/imark"
+chmod +x "$APP/Contents/Resources/imark"
+
 # The agent integration travels inside the app: the script that does the work,
 # and the skill and commands that point a coding agent at it. One source — the
 # same files the plugin ships — so the two can never drift apart, and the paths

--- a/release.sh
+++ b/release.sh
@@ -84,6 +84,7 @@ if [ "${1:-}" != "--force" ]; then
 		-o /tmp/imark-release-update >/dev/null 2>&1 \
 		&& /tmp/imark-release-update >/dev/null || die "the update comparison tests failed"
 	swift Support/test-plus.swift >/dev/null 2>&1 || die "the margin button tests failed"
+	swift Support/test-pieces.swift >/dev/null 2>&1 || die "the list and table note tests failed"
 	swift Support/test-front-matter.swift >/dev/null 2>&1 || die "the front matter tests failed"
 	Support/test-review.sh >/dev/null 2>&1 || die "the review round trip tests failed"
 	# test-setup.sh needs an assembled app, so it runs after the build instead.
@@ -106,6 +107,8 @@ if [ "${1:-}" != "--force" ]; then
 	step "installer checks"
 	IMARK_APP="$APP" Support/test-setup.sh >/dev/null 2>&1 \
 		|| die "the agent setup tests failed"
+	IMARK_APP="$APP" Support/test-cli.sh >/dev/null 2>&1 \
+		|| die "the command line tests failed"
 	echo "setup ok"
 fi
 

--- a/renderer/src/comments.js
+++ b/renderer/src/comments.js
@@ -220,6 +220,47 @@ function wrapQuote(block, quote, nth) {
   return first
 }
 
+/// The piece of a block a note is really about: the list item or the table cell
+/// the quote landed in, rather than the twenty-item list or the whole table
+/// that physically follows the note in the file.
+///
+/// A note cannot be written *into* a list in the file — an HTML comment between
+/// two items splits the list in half, and blanking those lines again to render
+/// it turns a tight list loose — so it stays after the block, as it always did,
+/// and the quote is what says which item. This is the other half of that: on
+/// screen, the dot goes where the words are.
+const PIECE = 'li, td, th'
+
+/// The words of a piece, its own and not those of a list nested inside it. A
+/// list item that contains a nested list would otherwise be quoted as the whole
+/// subtree — three lines of note header for a note about one line of list.
+///
+/// Exported because main.js writes the quote and this file reads it back, and
+/// the two have to agree on what "the whole of this item" means.
+export const pieceText = (piece) => {
+  let text = ''
+  for (const node of piece.childNodes) {
+    if (node.nodeType === Node.ELEMENT_NODE && /^(UL|OL|TABLE)$/.test(node.tagName)) break
+    text += node.textContent
+  }
+  return text.trim()
+}
+
+const pieceOf = (node, block) => {
+  const piece = node?.closest?.(PIECE)
+  return piece && block.contains(piece) && piece !== block ? piece : null
+}
+
+/// How far down the holder a dot has to sit to be beside the words it belongs
+/// to. Measured rather than counted: rows and items are whatever height their
+/// content made them, and the note has to find the third one of nineteen.
+function offsetIn(holder, element) {
+  if (!element || element === holder) return 0
+  const home = holder.getBoundingClientRect()
+  const box = element.getBoundingClientRect()
+  return Math.max(0, Math.round(box.top - home.top))
+}
+
 /// The dot and the card have to be positioned against the block, and a block
 /// can be a table or a list that will not accept stray children. Wrapping is
 /// the one approach that works for every block type.
@@ -319,6 +360,19 @@ export function attachComments(root, comments) {
       if (note.colour) block.dataset.color = note.colour
     }
 
+    // A quote that is the whole of one list item or one table cell came from
+    // the `+` beside that piece: "this item", not "these words". Underlining
+    // every word of it says the wrong thing, so the piece takes the wash the
+    // same way a whole block does.
+    const piece = pieceOf(anchor, block)
+    if (piece && anchor && pieceText(piece) === note.quote.trim()) {
+      piece.classList.add('note-piece')
+      if (note.colour) piece.dataset.color = note.colour
+      for (const span of piece.querySelectorAll('.note-anchor')) {
+        span.classList.add('is-whole')
+      }
+    }
+
     const dot = document.createElement('button')
     dot.type = 'button'
     dot.className = lost ? 'note-dot orphan' : (aboutBlock ? 'note-dot block' : 'note-dot')
@@ -326,10 +380,17 @@ export function attachComments(root, comments) {
     dot.dataset.note = note.id
     if (note.colour) dot.dataset.color = note.colour
     dot.setAttribute('aria-label', lost ? 'Comment with a missing quote' : 'Comment')
-    // Two notes on one paragraph would otherwise sit exactly on top of each
-    // other and only the last one would be clickable.
-    const stacked = holder.querySelectorAll('.note-dot').length
-    if (stacked) dot.style.top = `${2 + stacked * 17}px`
+    // Down the holder to the item, row or cell the quote is in. A list of
+    // twenty items used to put every dot at the top of the list, which said a
+    // note existed somewhere in there and left you to click all of them.
+    const top = offsetIn(holder, piece ?? anchor ?? block)
+    // Two notes on the same words would otherwise sit exactly on top of each
+    // other and only the last one would be clickable. Counted per height, so a
+    // note further down the list does not push the next one off its own row.
+    const stacked = [...holder.querySelectorAll('.note-dot')]
+      .filter((other) => Math.abs(Number.parseInt(other.style.top || '2', 10) - (top + 2)) < 12)
+      .length
+    dot.style.top = `${top + 2 + stacked * 17}px`
     holder.appendChild(dot)
     holder.appendChild(buildCard(note, lost))
     attached.push({

--- a/renderer/src/main.js
+++ b/renderer/src/main.js
@@ -18,6 +18,7 @@ import {
   extractComments,
   installCommentHandlers,
   isReviewing,
+  pieceText,
   restoreNoteState,
   setReviewing as applyReviewing,
   stepNote,
@@ -926,6 +927,19 @@ function selectionInfo() {
   }
 }
 
+/// Which copy of these words the piece is, counted the same way a selection is
+/// counted, because the note is read back by looking for the nth occurrence of
+/// the quote in the block. Two identical rows in a table are not rare.
+function occurrenceOfPiece(block, piece, quote) {
+  const range = document.createRange()
+  try {
+    range.setStartBefore(piece)
+  } catch {
+    return 1
+  }
+  return countBefore(block, range, quote)
+}
+
 /// How many times the selected text already appeared in this block before the
 /// point where the selection starts, plus one.
 function countBefore(block, range, text) {
@@ -953,6 +967,7 @@ function countBefore(block, range, text) {
 /// one it is, and it can never come loose the way a quote can.
 let plusButton = null
 let plusTarget = null
+let plusBlock = null
 /// Hiding is delayed, because the way to the button leads out of the text: the
 /// pointer crosses the margin, which belongs to no block, and hiding on the
 /// first frame outside meant the button vanished exactly as you reached for it.
@@ -993,6 +1008,32 @@ const PLUS_REACH = 120
 /// And how much of each edge it never touches, because the rails are there.
 const RAIL_GUTTER = 56
 
+/// A list item or a table cell: the piece of a block somebody points at when
+/// they point at a list or a table. Agents write long lists, and a note on the
+/// list as a whole leaves the reader — human or agent — to work out which of
+/// nineteen items it meant.
+const PIECE = 'li, td, th'
+
+/// The piece of `block` under `node`, if any. The innermost one, so a list
+/// inside a list item answers with the item you are actually on.
+const pieceIn = (block, node) => {
+  const piece = node?.closest?.(PIECE)
+  return piece && block.contains(piece) ? piece : null
+}
+
+/// Out in the margin there is nothing under the pointer to ask, so the question
+/// goes to the text at the same height instead.
+///
+/// Only a list answers it. Items are stacked, so the one level with the pointer
+/// is the one meant — while a table row has three or four cells at that height
+/// and answering with the first would be a guess dressed up as an offer. Beside
+/// a table the margin still offers the table, and a cell has to be pointed at.
+function itemAtHeight(block, clientY) {
+  const box = block.getBoundingClientRect()
+  const item = document.elementFromPoint(box.left + 8, clientY)?.closest?.('li')
+  return item && block.contains(item) ? item : null
+}
+
 const topLevelBlock = (node) => {
   const root = content()
   let block = node
@@ -1008,19 +1049,25 @@ const topLevelBlock = (node) => {
 function hidePlus() {
   plusTarget?.classList.remove('block-target', 'block-armed')
   plusTarget = null
+  plusBlock = null
   if (plusButton) plusButton.style.display = 'none'
 }
 
-function showPlus(block) {
+/// `target` is what lights up and what the note will be about — a whole block,
+/// or one item or cell inside it. `block` is the top-level element it lives in,
+/// which is where the note goes in the file: an HTML comment written between
+/// two list items or two table rows would break the list or the table in half.
+function showPlus(target, block) {
   if (!plusButton) return
-  if (plusTarget === block) return
+  plusBlock = block
+  if (plusTarget === target) return
   plusTarget?.classList.remove('block-target', 'block-armed')
-  plusTarget = block
+  plusTarget = target
   // Lit as soon as the button appears, not only once the pointer reaches it.
   // Waiting meant the highlight never showed at all if you never got there.
-  block.classList.add('block-target')
+  target.classList.add('block-target')
 
-  const rect = block.getBoundingClientRect()
+  const rect = target.getBoundingClientRect()
   plusButton.style.display = 'flex'
   plusButton.style.top = `${rect.top + 1}px`
   plusButton.style.left = `${Math.max(4, rect.left - 34)}px`
@@ -1045,20 +1092,28 @@ function setUpBlockPlus() {
   })
 
   plusButton.addEventListener('click', () => {
-    const block = plusTarget
+    const target = plusTarget
+    const block = plusBlock ?? plusTarget
     const lines = lineRange(block)
-    if (!block || !lines) return
-    const rect = block.getBoundingClientRect()
-    block.classList.add('block-target')
-    // The same message a selection sends, with no text. Everything downstream
-    // already carries the quote through as a string; empty means "the block".
+    if (!target || !block || !lines) return
+    const rect = target.getBoundingClientRect()
+    target.classList.add('block-target')
+    // On a whole block: no text. Everything downstream already carries the
+    // quote through as a string, and empty means "the block".
+    //
+    // On one item or one cell, the piece's own words are the quote. The note
+    // still lands after the block in the file, so its words are the only thing
+    // that can say which item it was about — to the renderer, and to whoever
+    // reads the file without ever opening the app.
+    const piece = target === block ? null : target
+    const quote = piece ? pieceText(piece) : ''
     bridge({
       type: 'selection',
-      text: '',
+      text: quote,
       rect: { x: rect.left, y: rect.top, width: rect.width, height: Math.min(rect.height, 24) },
-      inline: lines,
+      inline: lineRange(target.closest('[data-line]')) ?? lines,
       block: lines,
-      occurrence: 1,
+      occurrence: piece ? occurrenceOfPiece(block, piece, quote) : 1,
     })
   })
 
@@ -1078,7 +1133,10 @@ function setUpBlockPlus() {
     const block = onText ?? blockAtHeight(event.clientX, event.clientY)
     if (!block || !lineRange(block)) return scheduleHide()
     cancelHide()
-    showPlus(block)
+    // Inside a list or a table the offer is for the item or the cell, whether
+    // the pointer is on the words or out in the margin beside them.
+    const piece = (onText && pieceIn(block, event.target)) ?? itemAtHeight(block, event.clientY)
+    showPlus(piece ?? block, block)
   })
 
   // Fixed positioning against a rect taken once — scrolling moves the block out

--- a/renderer/src/style.css
+++ b/renderer/src/style.css
@@ -904,6 +904,23 @@ img[data-blocked] {
   margin-left: calc(var(--step) * -3);
 }
 
+/* One item of a list, or one cell of a table, carrying a note of its own. The
+   same idea as .note-block and quieter still: it sits inside a block that may
+   already be washed, and the bar down the left has a column rule and a bullet
+   to share the space with. */
+.note-piece {
+  background: color-mix(in srgb, var(--note) 10%, transparent);
+  box-shadow: inset 2px 0 0 0 var(--note);
+  border-radius: 3px;
+}
+
+/* The words of such a note are the whole of the piece, and the wash already
+   says so. Underlining them as well draws a line under an entire table row. */
+.note-anchor.is-whole {
+  background: none;
+  border-bottom: 0;
+}
+
 /* Notes about the document itself, above everything. They have nothing in the
    page to point at, so unlike every other card these are open from the start —
    one that had to be found by clicking would never be read. */


### PR DESCRIPTION
Closes #14, #15, #16.

## Notes on one list item or one table cell (#15, #16)

A note cannot be written *into* a list. An HTML comment between two items splits
the list in half, and blanking those lines again to render it turns a tight list
loose. So the file format does not change: notes stay after the block and the
`quote=` says which item.

What was missing was everything around that.

- The `+` in the margin now offers the **item or the cell** the pointer is level
  with, and writes that piece's own words as the quote — so the file names the
  item to anyone reading it without the app.
- A note's dot now sits **beside the words it quotes** instead of at the top of
  the block. A nineteen-item list used to get one dot at the top. This also
  means a note on the third line of a long paragraph now points at that line.
- A piece quoted whole takes a **wash** rather than an underline: "this item"
  reads differently from "these words".
- Beside a table the margin still offers the table. A row has four cells level
  with the pointer, and answering with the first would be a guess dressed up as
  an offer, so a cell has to be pointed at.

New suite: `Support/test-pieces.swift`, driving it in a real web view — where the
dot lands, what the `+` sends, which copy of a repeated cell it counts.

## `imark` on the PATH (#14)

`imark notes.md` opens a document in the copy already running and brings it
forward if it is already open; `imark notes file.md` and `imark review file.md`
reach the script the coding agents already use.

The script ships inside the bundle and is installed by **symlink** from the Imark
menu, so it can never be a version behind the app it opens documents in, and
deleting one link undoes it. It goes to `/usr/local/bin` when that is writable
and `~/.local/bin` otherwise — the alert says which before it writes anything,
and refuses to overwrite an `imark` it did not put there.

Kept separate from making Imark the default for `.md` on purpose, which is the
point of the issue: `open notes.md` should still go to your editor.

New suite: `Support/test-cli.sh` and `Support/test-cli.swift`.

## The `(1)` in "0.4.0 (1)"

`CFBundleVersion` was `1` in every release ever made, so the About panel — and
every bug report copied out of it — carried a build number that told nobody
anything. `Support/bump.sh` now writes it alongside the version and `--check`
holds it there, which is also what makes macOS show the version on its own.

---

Both new suites are in `release.sh` and `CONTRIBUTING.md`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)