### PR TITLE
Prepare Imark 0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Review plans, diffs and documents in Imark, the offline macOS markdown reader.",
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "plugins": [
     {

--- a/Support/Imark-Info.plist
+++ b/Support/Imark-Info.plist
@@ -34,9 +34,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
+	<string>0.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.4.0</string>
+	<string>0.5.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Support/QuickLook-Info.plist
+++ b/Support/QuickLook-Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
+	<string>0.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.4.0</string>
+	<string>0.5.0</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "imark",
   "description": "Review plans, diffs and documents in Imark. The agent writes markdown, you comment on it in the app, and your notes come back — through the file, with no server in between.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "migsilva89"
   },


### PR DESCRIPTION
Sets the app, Quick Look extension, Claude Code plugin, and marketplace entry to 0.5.0.

This release includes signed in-app updates, precise notes on list items and table cells, and the bundled `imark` command.

`Support/bump.sh --check` passes.
