### PR TITLE
Build the renderer before release tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Run the suites. `./release.sh` refuses to build if any of them fail, so a change
 that breaks one cannot ship anyway.
 
 ```bash
+(cd renderer && node build.mjs)
 Support/test-review.sh
 swift build
 TEST_BIN="$(swift build --show-bin-path)"

--- a/release.sh
+++ b/release.sh
@@ -61,6 +61,11 @@ if [ "${1:-}" != "--force" ]; then
 
 	# The suites, because a signed and notarised broken build is worse than an
 	# unsigned one: it carries somebody's name and opens without a warning.
+	# The web-view suites exercise the generated bundle, not renderer/src. Build
+	# it first so a clean checkout cannot test whatever Resources/ happened to
+	# contain from an older branch.
+	(cd renderer && node build.mjs) >/dev/null 2>&1 \
+		|| die "the renderer failed to build"
 	swiftc -parse-as-library Sources/Imark/Comments.swift Sources/Imark/NoteColour.swift \
 		Support/test-comments.swift -o /tmp/imark-release-test >/dev/null 2>&1 \
 		&& /tmp/imark-release-test >/dev/null || die "the comment tests failed"


### PR DESCRIPTION
The WebKit suites read the generated `Resources/` bundle. Build it before the release gate so a clean checkout tests the current renderer rather than an ignored bundle left by an older branch.

The margin and list/table suites pass after rebuilding.
