### PR TITLE
Publish the update image under its own name

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -83,7 +83,12 @@ somebody's name and opens without a warning. `--force` skips the gate and is for
 when you know exactly why.
 
 It leaves `dist/Imark-<version>.dmg`, signed, notarised and stapled, plus
-`dist/appcast.xml`, the signed feed that tells installed copies about it.
+`dist/appcast.xml`, the signed feed that tells installed copies about it, plus
+`dist/Imark-<version>-update.dmg` — the same image, byte for byte, under the
+name the feed points at. Two names for one build is the only way to read the
+download counters apart: GitHub counts per asset, so the plain name is people
+installing Imark for the first time and the `-update` one is copies updating
+themselves.
 Notarisation is Apple looking at the binary and takes a few minutes.
 
 Either variable can be left out. Without `IMARK_NOTARY_PROFILE` you get a signed
@@ -107,15 +112,20 @@ else.
 
 ## Publishing
 
-Tag the commit and attach both files to the same GitHub release. The feed has a
-stable `releases/latest/download/appcast.xml` address, so the app follows the
-new release without a second server or repository to update:
+Tag the commit and attach all three files to the same GitHub release. The feed
+has a stable `releases/latest/download/appcast.xml` address, so the app follows
+the new release without a second server or repository to update:
 
 ```bash
 git tag v0.1.0 && git push origin v0.1.0
-gh release create v0.1.0 dist/Imark-0.1.0.dmg dist/appcast.xml \
-  --title "Imark 0.1.0" --notes "…"
+gh release create v0.1.0 dist/Imark-0.1.0.dmg dist/Imark-0.1.0-update.dmg \
+  dist/appcast.xml --title "Imark 0.1.0" --notes "…"
 ```
+
+Leaving the `-update` image out publishes a feed that points at an asset which
+is not there, and every installed copy fails its update with a 404. The site
+and Homebrew both name the plain image explicitly, so neither is confused by
+the second one.
 
 GitHub does not serve release assets from a private repository, so the repo has
 to be public before the download link works for anyone else.

--- a/Support/appcast.sh
+++ b/Support/appcast.sh
@@ -2,6 +2,11 @@
 # Signs one finished disk image and writes the Sparkle feed published beside it.
 # The private EdDSA key stays in the login keychain under the `imark` account;
 # only its public half is in the app's Info.plist.
+#
+# The feed points at a second, identically-built copy of the image, published
+# under the `-update` name. Same bytes, same signature, different GitHub asset —
+# which is the only way to tell an update apart from a first install, since
+# GitHub counts downloads per asset and nothing else.
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -13,6 +18,7 @@ TOOLS="$ROOT/.build/artifacts/sparkle/Sparkle/bin"
 GENERATE="$TOOLS/generate_appcast"
 KEYS="$TOOLS/generate_keys"
 OUTPUT="$ROOT/dist/appcast.xml"
+UPDATE_DMG="$ROOT/dist/Imark-$VERSION-update.dmg"
 
 [ -f "$DMG" ] || { echo "error: no disk image at $DMG" >&2; exit 1; }
 [ -x "$GENERATE" ] || {
@@ -29,7 +35,7 @@ ACTUAL="$("$KEYS" --account imark -p)"
 
 STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT
-ditto "$DMG" "$STAGE/$(basename "$DMG")"
+ditto "$DMG" "$STAGE/$(basename "$UPDATE_DMG")"
 
 "$GENERATE" \
 	--account imark \
@@ -42,10 +48,14 @@ ditto "$DMG" "$STAGE/$(basename "$DMG")"
 	"$STAGE"
 
 cp "$STAGE/appcast.xml" "$OUTPUT"
+cp "$DMG" "$UPDATE_DMG"
 xmllint --noout "$OUTPUT"
 grep -q 'sparkle:edSignature=' "$OUTPUT" \
 	|| { echo "error: the update in appcast.xml is not signed" >&2; exit 1; }
 grep -q '<!-- sparkle-signatures:' "$OUTPUT" \
 	|| { echo "error: appcast.xml itself is not signed" >&2; exit 1; }
+grep -q "$(basename "$UPDATE_DMG")" "$OUTPUT" \
+	|| { echo "error: the feed does not point at the update copy" >&2; exit 1; }
 
 echo "update feed → $OUTPUT"
+echo "update image → $UPDATE_DMG"

--- a/release.sh
+++ b/release.sh
@@ -28,6 +28,7 @@ APP="$ROOT/dist/Imark.app"
 STAGE="$ROOT/dist/dmg"
 DMG="$ROOT/dist/Imark-$VERSION.dmg"
 APPCAST="$ROOT/dist/appcast.xml"
+UPDATE_DMG="$ROOT/dist/Imark-$VERSION-update.dmg"
 
 step() { printf '\n\033[1;35m▸ %s\033[0m\n' "$1"; }
 die() { printf '\n\033[1;31m✗ %s\033[0m\n' "$1" >&2; exit 1; }
@@ -177,8 +178,13 @@ if [ -f "$APPCAST" ]; then
 	cat <<-EOF
 
 	then, to publish:
-	  gh release create v$VERSION "$DMG" "$APPCAST" --title "Imark $VERSION" --notes "…"
+	  gh release create v$VERSION "$DMG" "$UPDATE_DMG" "$APPCAST" \
+	    --title "Imark $VERSION" --notes "…"
 	  Support/tap.sh          point Homebrew at it
+
+	$(basename "$UPDATE_DMG") is the same image under a second name: the feed
+	points installed copies at it, so GitHub's per-asset counter separates
+	updates from first installs. Publish both or the updater 404s.
 	EOF
 else
 	cat <<-EOF


### PR DESCRIPTION
GitHub counts downloads per asset. With a single `.dmg` serving both the website and Sparkle's feed, a first install and a self-update were indistinguishable in the numbers.

Each release now carries a second, byte-identical copy of the image named `Imark-<version>-update.dmg`, and the appcast points only at that one:

- `Imark-<version>.dmg` — the website and the Homebrew cask, i.e. installs
- `Imark-<version>-update.dmg` — installed copies updating themselves

`Support/appcast.sh` writes the copy and fails if the generated feed does not name it. `release.sh` prints the `gh release create` line with all three files, and `RELEASING.md` says why the second name exists and that leaving it out 404s every updater.

Nothing here changes the app or an existing release; it takes effect on the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)