### PR TITLE
Tell the site when a release is published

### DIFF
--- a/.github/workflows/tell-the-site.yml
+++ b/.github/workflows/tell-the-site.yml
@@ -1,0 +1,48 @@
+name: Tell the site
+
+# The site prints the version and the download size from a file in its own
+# repository, so it asks GitHub nothing while it builds. Something has to keep
+# that file current, and until now the site asked: a schedule that reads this
+# repository's latest release every half hour.
+#
+# GitHub does not honour that schedule. On a repository with little traffic it
+# drops the ticks rather than queueing them — measured across all three sites,
+# the real gaps run from two to six hours. So every release spent an afternoon
+# with the website still offering the previous version.
+#
+# This is the other direction, and it takes seconds: publishing a release pokes
+# the website's repository, which rebuilds itself straight away. The schedule
+# stays on the other side as a safety net, for the case where this fails.
+
+on:
+  release:
+    types: [published]
+  # For firing it by hand — after a release published before this existed, or to
+  # prove the token still works without cutting a release to find out.
+  workflow_dispatch:
+
+# Nothing here reads or writes this repository. The only credential used is the
+# one that reaches the OTHER repository, and it arrives from a secret.
+permissions: {}
+
+jobs:
+  tell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Poke the website repository
+        env:
+          GH_TOKEN: ${{ secrets.SITE_DISPATCH_TOKEN }}
+          SITE: migsilva89/imark-site
+        run: |
+          set -euo pipefail
+          # A missing token is a warning, not a failure. Without it the site
+          # still catches up on its own schedule — hours late, but correct — and
+          # a red cross on a release that published perfectly reads as a broken
+          # release rather than as a missing setting.
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::No SITE_DISPATCH_TOKEN set, so $SITE was not told."
+            echo "::warning::It will pick this release up on its own schedule instead, which GitHub throttles to every few hours."
+            exit 0
+          fi
+          gh api -X POST "repos/$SITE/dispatches" -f event_type=release-published
+          echo "Told $SITE that a release was published."


### PR DESCRIPTION
The site reads its version and download size from a file in its own repository, so it asks GitHub nothing while it builds. A schedule on **that** side kept the file current by polling this repository every half hour.

**GitHub does not honour that schedule.** On a repository with little traffic it drops the ticks rather than queueing them. Measured on each site's own workflow runs, the real gaps:

| | |
|---|---|
| imark-site | 6.1h, 2.2h, 2.6h, 3.0h, 4.5h |
| loadout-website | 6.7h, 4.2h, 2.3h, 3.0h, 3.7h |
| unbury-website | 2.1h, 6.4h, 2.7h, 2.4h, 3.0h, 3.7h, 4.7h |

So every release spent between two and six hours with the website still offering the previous version. That is what happened to Unbury 0.1.1 today, and it has been happening quietly to all three for weeks.

## What this does

Publishing a release pokes the matching website repository directly, and it rebuilds in seconds. The schedule stays on the other side as a safety net for the case where this step fails.

## It needs one secret, and works without it

`SITE_DISPATCH_TOKEN` — a fine-grained token with **Contents: write** on the site repository, which is what `repository_dispatch` requires.

Until that secret exists the step warns and passes rather than failing. A red cross on a release that published perfectly reads as a broken release rather than as a missing setting, and the site still catches up on its own schedule in the meantime — hours late, but correct.

`permissions: {}` — nothing here reads or writes this repository. The only credential is the one that reaches the other one.